### PR TITLE
chore(watashi-compass): add Authentic-Life-AI LP as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "products/2-validation/2025-08-006-watashi-compass/lp"]
+	path = products/2-validation/2025-08-006-watashi-compass/lp
+	url = https://github.com/Unson-LLC/Authentic-Life-AI


### PR DESCRIPTION
Adds the Watashi Compass LP repository as a Git submodule under:
- products/2-validation/2025-08-006-watashi-compass/lp

Notes:
- Keeps existing product files (product.yaml, phases) intact
- Aligns with other products that place LP under an `lp` subfolder
- To update submodule: `git submodule update --remote --merge` (optional)