### PR TITLE
feat(lp-validation): display Google Ads history on position detail

### DIFF
--- a/apps/lp-validation/src/app/api/positions/[id]/ads/route.ts
+++ b/apps/lp-validation/src/app/api/positions/[id]/ads/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+// シンプルなファイルベース取り込み: products/**/<productId>/ads/history.json を探す
+async function findHistoryPath(productId: string): Promise<string | null> {
+  // 既知の配置パターン: products/2-validation/<id>/ads/history.json
+  const candidate = path.join(process.cwd(), 'products', '2-validation', productId, 'ads', 'history.json')
+  try {
+    await fs.access(candidate)
+    return candidate
+  } catch {}
+
+  // 汎用探索（浅め）: products/*/*/<id>/ads/history.json
+  const productsRoot = path.join(process.cwd(), 'products')
+  const stages = await fs.readdir(productsRoot).catch(() => [])
+  for (const stage of stages) {
+    const stageDir = path.join(productsRoot, stage)
+    try {
+      const entries = await fs.readdir(stageDir)
+      for (const e of entries) {
+        if (e === productId) {
+          const p = path.join(stageDir, e, 'ads', 'history.json')
+          try {
+            await fs.access(p)
+            return p
+          } catch {}
+        }
+      }
+    } catch {}
+  }
+  return null
+}
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const p = await findHistoryPath(params.id)
+    if (!p) return NextResponse.json({ ads: [] })
+    const raw = await fs.readFile(p, 'utf8')
+    const data = JSON.parse(raw)
+    // 期待スキーマ: [{ date: '2025-08-01', impressions: 1234, clicks: 56, cost: 1234, conversions: 7 }]
+    const ads = Array.isArray(data) ? data : (data.items || [])
+    return NextResponse.json({ ads })
+  } catch (e) {
+    return NextResponse.json({ ads: [] })
+  }
+}
+

--- a/apps/lp-validation/src/app/position/[id]/page.tsx
+++ b/apps/lp-validation/src/app/position/[id]/page.tsx
@@ -16,6 +16,7 @@ export default function PositionDetailPage() {
   const positionId = params.id as string
   const [positionData, setPositionData] = useState<any>({})
   const [logs, setLogs] = useState<any[]>([])
+  const [ads, setAds] = useState<any[]>([])
   useEffect(() => {
     const load = async () => {
       const res = await fetch(`/api/positions/${positionId}`, { cache: 'no-store' })
@@ -41,6 +42,12 @@ export default function PositionDetailPage() {
       if (ex.ok) {
         const data = await ex.json()
         setLogs(data.executions || [])
+      }
+      // google ads history (ファイルベース; あれば表示)
+      const adsRes = await fetch(`/api/positions/${positionId}/ads`, { cache: 'no-store' })
+      if (adsRes.ok) {
+        const { ads } = await adsRes.json()
+        if (Array.isArray(ads)) setAds(ads)
       }
     }
     load()
@@ -302,6 +309,35 @@ export default function PositionDetailPage() {
 
           {/* サイドバー */}
           <div className="space-y-6">
+            {/* Google Ads 履歴 */}
+            {ads.length > 0 && (
+              <div className="bg-white border border-gray-200 rounded-lg">
+                <div className="bg-gray-50 border-b border-gray-200 p-6">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-6 h-6 bg-red-500 rounded-md flex items-center justify-center">
+                      <BarChart3 className="w-3 h-3 text-white" />
+                    </div>
+                    <h2 className="text-lg font-semibold text-gray-900">広告履歴（Google Ads）</h2>
+                  </div>
+                  <p className="text-sm text-gray-600 mt-1">インプレッション / クリック / コスト / CV</p>
+                </div>
+                <div className="p-6 space-y-3">
+                  {ads.slice(0, 10).map((d, i) => {
+                    const ctr = d.impressions ? Math.round((d.clicks / d.impressions) * 1000) / 10 : 0
+                    const cpc = d.clicks ? Math.round((d.cost / d.clicks)) : 0
+                    return (
+                      <div key={i} className="grid grid-cols-5 gap-2 text-sm items-center border border-gray-100 rounded-lg p-3">
+                        <div className="text-gray-600">{d.date}</div>
+                        <div className="text-gray-900">Imp {d.impressions?.toLocaleString?.() || d.impressions}</div>
+                        <div className="text-gray-900">Clk {d.clicks?.toLocaleString?.() || d.clicks} <span className="text-xs text-gray-500">({ctr}%)</span></div>
+                        <div className="text-gray-900">Cost ¥{d.cost?.toLocaleString?.() || d.cost} <span className="text-xs text-gray-500">(CPC ¥{cpc})</span></div>
+                        <div className="text-gray-900">CV {d.conversions?.toLocaleString?.() || d.conversions}</div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
             {/* ユーザー行動フロー */}
             <div className="bg-white border border-gray-200 rounded-lg">
               <div className="bg-gray-50 border-b border-gray-200 p-6">

--- a/products/2-validation/2025-08-006-watashi-compass/ads/history.sample.json
+++ b/products/2-validation/2025-08-006-watashi-compass/ads/history.sample.json
@@ -1,0 +1,17 @@
+[
+  {
+    "date": "2025-08-10",
+    "impressions": 1820,
+    "clicks": 92,
+    "cost": 3480,
+    "conversions": 6
+  },
+  {
+    "date": "2025-08-11",
+    "impressions": 2015,
+    "clicks": 103,
+    "cost": 3920,
+    "conversions": 7
+  }
+]
+


### PR DESCRIPTION
Adds Ads history panel for positions with real ad data.\n\n- API: /api/positions/[id]/ads reads products/**/<id>/ads/history.json\n- UI: New sidebar section shows daily Imp/Clk/Cost/CV with CTR/CPC\n- Sample: products/2-validation/2025-08-006-watashi-compass/ads/history.sample.json\n\nHow to enable for Watashi Compass:\n1) Export daily metrics from Google Ads (date, impressions, clicks, cost, conversions)\n2) Save as JSON at products/2-validation/2025-08-006-watashi-compass/ads/history.json\n3) Open position detail page for 2025-08-006-watashi-compass\n\nFuture: swap file-ingest for live API once credentials are configured.