### PR TITLE
feat(ads): support 4-hour Google Ads windows

### DIFF
--- a/apps/lp-validation/src/app/api/positions/[id]/ads/route.ts
+++ b/apps/lp-validation/src/app/api/positions/[id]/ads/route.ts
@@ -25,19 +25,38 @@ function client() {
   return new ConvexHttpClient(resolveConvexUrl())
 }
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
     const c = client()
-    const items = await c.query(api.ads.getDailyMetricsByProduct, { product_id: params.id, limit: 30 })
-    // normalize to UI shape
-    const ads = (items || []).map((it: any) => ({
-      date: it.date,
-      impressions: it.impressions,
-      clicks: it.clicks,
-      cost: it.cost,
-      conversions: it.conversions,
-    }))
-    return NextResponse.json({ ads })
+    const { searchParams } = new URL(req.url)
+    const gran = (searchParams.get('granularity') || '4h').toLowerCase()
+    if (gran === '4h' || gran === 'window') {
+      const items = await c.query(api.ads.getWindowMetricsByProduct, { product_id: params.id, window_hours: 4, limit: 24 })
+      const ads = (items || []).map((it: any) => {
+        const d = new Date(it.ts_start)
+        const mm = String(d.getMonth() + 1).padStart(2, '0')
+        const dd = String(d.getDate()).padStart(2, '0')
+        const hh = String(d.getHours()).padStart(2, '0')
+        return {
+          date: `${d.getFullYear()}-${mm}-${dd} ${hh}:00`,
+          impressions: it.impressions,
+          clicks: it.clicks,
+          cost: it.cost,
+          conversions: it.conversions,
+        }
+      })
+      return NextResponse.json({ ads })
+    } else {
+      const items = await c.query(api.ads.getDailyMetricsByProduct, { product_id: params.id, limit: 30 })
+      const ads = (items || []).map((it: any) => ({
+        date: it.date,
+        impressions: it.impressions,
+        clicks: it.clicks,
+        cost: it.cost,
+        conversions: it.conversions,
+      }))
+      return NextResponse.json({ ads })
+    }
   } catch (e) {
     return NextResponse.json({ ads: [] })
   }
@@ -50,23 +69,41 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     if (!Array.isArray(items)) {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
     }
-    // workspaceを最新セッションから推定する
     const c = client()
     const sessions = await c.query(api.lpValidation.getSessionsByProduct, { productId: params.id, limit: 1 })
     const s = sessions[0]
     const workspace_id = s?.workspace_id || 'unson_main'
-    await c.mutation(api.ads.importDailyMetrics, {
-      workspace_id,
-      product_id: params.id,
-      items: items.map((d: any) => ({
-        date: d.date,
-        impressions: Number(d.impressions || 0),
-        clicks: Number(d.clicks || 0),
-        cost: Number(d.cost || 0),
-        conversions: Number(d.conversions || 0),
-        platform: d.platform || 'Google Ads',
-      }))
-    })
+
+    // Determine import mode: windowed (4h) vs daily
+    const mode = (body.mode || body.granularity || '').toLowerCase()
+    if (mode === '4h' || mode === 'window') {
+      await c.mutation(api.ads.importWindowMetrics, {
+        workspace_id,
+        product_id: params.id,
+        window_hours: Number(body.windowHours || 4),
+        items: items.map((d: any) => ({
+          ts_start: Number(d.ts_start ?? d.timestamp ?? Date.parse(d.datetime || d.date) || 0),
+          impressions: Number(d.impressions || 0),
+          clicks: Number(d.clicks || 0),
+          cost: Number(d.cost || 0),
+          conversions: Number(d.conversions || 0),
+          platform: d.platform || 'Google Ads',
+        })),
+      })
+    } else {
+      await c.mutation(api.ads.importDailyMetrics, {
+        workspace_id,
+        product_id: params.id,
+        items: items.map((d: any) => ({
+          date: d.date,
+          impressions: Number(d.impressions || 0),
+          clicks: Number(d.clicks || 0),
+          cost: Number(d.cost || 0),
+          conversions: Number(d.conversions || 0),
+          platform: d.platform || 'Google Ads',
+        })),
+      })
+    }
     return NextResponse.json({ success: true, count: items.length })
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Failed to import' }, { status: 500 })

--- a/convex/ads.ts
+++ b/convex/ads.ts
@@ -65,3 +65,72 @@ export const importDailyMetrics = mutation({
   },
 });
 
+export const getWindowMetricsByProduct = query({
+  args: {
+    product_id: v.string(),
+    window_hours: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 24; // default last 24 windows
+    let q = ctx.db
+      .query("adsWindowMetrics")
+      .withIndex("by_product_ts", (q) => q.eq("product_id", args.product_id))
+      .order("desc");
+    if (args.window_hours) {
+      q = q.filter((qq) => qq.eq(qq.field("window_hours"), args.window_hours));
+    }
+    return await q.take(limit);
+  },
+});
+
+export const importWindowMetrics = mutation({
+  args: {
+    workspace_id: v.string(),
+    product_id: v.string(),
+    window_hours: v.number(),
+    items: v.array(v.object({
+      ts_start: v.number(), // ms epoch for window start
+      impressions: v.number(),
+      clicks: v.number(),
+      cost: v.number(),
+      conversions: v.number(),
+      platform: v.optional(v.string()),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    for (const it of args.items) {
+      const existing = await ctx.db
+        .query("adsWindowMetrics")
+        .withIndex("by_product_ts", (q) => q.eq("product_id", args.product_id).eq("ts_start", it.ts_start))
+        .first();
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          impressions: it.impressions,
+          clicks: it.clicks,
+          cost: it.cost,
+          conversions: it.conversions,
+          platform: it.platform || existing.platform,
+          window_hours: args.window_hours,
+          updated_at: now,
+        });
+      } else {
+        await ctx.db.insert("adsWindowMetrics", {
+          workspace_id: args.workspace_id,
+          product_id: args.product_id,
+          platform: it.platform || 'Google Ads',
+          ts_start: it.ts_start,
+          window_hours: args.window_hours,
+          impressions: it.impressions,
+          clicks: it.clicks,
+          cost: it.cost,
+          conversions: it.conversions,
+          created_at: now,
+          updated_at: now,
+        });
+      }
+    }
+    return { success: true, count: args.items.length };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -467,6 +467,23 @@ export default defineSchema({
     .index("by_product_date", ["product_id", "date"]) 
     .index("by_workspace_product", ["workspace_id", "product_id"]),
 
+  // Google Ads 時間窓メトリクス（例: 4時間）
+  adsWindowMetrics: defineTable({
+    workspace_id: v.string(),
+    product_id: v.string(),
+    platform: v.optional(v.string()), // 'Google Ads'
+    ts_start: v.number(), // window start timestamp (ms)
+    window_hours: v.number(), // e.g., 4
+    impressions: v.number(),
+    clicks: v.number(),
+    cost: v.number(), // JPY
+    conversions: v.number(),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_product_ts", ["product_id", "ts_start"]) 
+    .index("by_workspace_product", ["workspace_id", "product_id"]),
+
   phaseReviews: defineTable({
     workspace_id: v.string(),
     productId: v.string(),


### PR DESCRIPTION
Adds adsWindowMetrics table + functions and updates API to serve 4h windows by default (granularity param supported). UI already renders timestamps, so no changes needed.