### PR TITLE
feat(services): 全サービス名を正式名に統一 - ユーザー本音重視の実用的命名

### DIFF
--- a/apps/lp-validation/__tests__/time-series-list.test.tsx
+++ b/apps/lp-validation/__tests__/time-series-list.test.tsx
@@ -20,7 +20,7 @@ describe('TimeSeriesList', () => {
       render(<TimeSeriesList {...mockProps} />);
       
       // ヘッダー確認
-      expect(screen.getByText('AI-COACH 行動ログ')).toBeInTheDocument();
+      expect(screen.getByText('じぶん lab 行動ログ')).toBeInTheDocument();
       
       // 時間範囲フィルター確認
       expect(screen.getByText('4時間')).toBeInTheDocument();

--- a/apps/lp-validation/__tests__/trading-dashboard.test.tsx
+++ b/apps/lp-validation/__tests__/trading-dashboard.test.tsx
@@ -27,7 +27,7 @@ describe('TradingDashboard', () => {
       expect(screen.getByText('(+45/日)')).toBeInTheDocument();
       
       // ポジション行の確認
-      expect(screen.getByText('AI-COACH')).toBeInTheDocument();
+      expect(screen.getByText('じぶん lab')).toBeInTheDocument();
       expect(screen.getByText('15.2%')).toBeInTheDocument(); // CVR
       expect(screen.getByText('¥180')).toBeInTheDocument();  // CPL
       expect(screen.getByText('125')).toBeInTheDocument();   // リード数
@@ -42,9 +42,9 @@ describe('TradingDashboard', () => {
       const warningPositions = screen.getAllByText('🟡');
       const errorPositions = screen.getAllByText('🔴');
       
-      expect(runningPositions).toHaveLength(2); // AI-COACH, AI-WRITER
-      expect(warningPositions).toHaveLength(1); // AI-BRIDGE
-      expect(errorPositions).toHaveLength(1);   // AI-STYLIST
+      expect(runningPositions).toHaveLength(2); // じぶん lab, AI-WRITER
+      expect(warningPositions).toHaveLength(1); // 世代bridge
+      expect(errorPositions).toHaveLength(1);   // きこなし
     });
 
     it('AIコメントが各ポジションに表示される', () => {
@@ -66,10 +66,10 @@ describe('TradingDashboard', () => {
       
       // ソート後の順序確認
       const positionRows = screen.getAllByTestId('position-row');
-      expect(positionRows[0]).toHaveTextContent('AI-COACH'); // 15.2%
+      expect(positionRows[0]).toHaveTextContent('じぶん lab'); // 15.2%
       expect(positionRows[1]).toHaveTextContent('AI-WRITER'); // 12.8%
-      expect(positionRows[2]).toHaveTextContent('AI-BRIDGE'); // 8.2%
-      expect(positionRows[3]).toHaveTextContent('AI-STYLIST'); // 3.4%
+      expect(positionRows[2]).toHaveTextContent('世代bridge'); // 8.2%
+      expect(positionRows[3]).toHaveTextContent('きこなし'); // 3.4%
     });
 
     it('実行中のみフィルターができる', async () => {
@@ -79,9 +79,9 @@ describe('TradingDashboard', () => {
       fireEvent.click(filterButton);
       
       // フィルター後の表示確認
-      expect(screen.getByText('AI-COACH')).toBeInTheDocument();
+      expect(screen.getByText('じぶん lab')).toBeInTheDocument();
       expect(screen.getByText('AI-WRITER')).toBeInTheDocument();
-      expect(screen.queryByText('AI-STYLIST')).not.toBeInTheDocument(); // 停止中は非表示
+      expect(screen.queryByText('きこなし')).not.toBeInTheDocument(); // 停止中は非表示
     });
   });
 

--- a/apps/lp-validation/src/app/admin/page.tsx
+++ b/apps/lp-validation/src/app/admin/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useState } from 'react';
+
+export default function AdminPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const seedSampleData = async () => {
+    setIsLoading(true);
+    setMessage('');
+    
+    try {
+      const response = await fetch('/api/seed-sample-data', {
+        method: 'POST',
+      });
+      
+      const result = await response.json();
+      
+      if (result.success) {
+        setMessage(`✅ ${result.message}`);
+      } else {
+        setMessage(`❌ エラー: ${result.message}`);
+      }
+    } catch (error) {
+      setMessage(`❌ 通信エラー: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const deleteAllData = async () => {
+    if (!confirm('全てのセッションデータを削除しますか？この操作は取り消せません。')) {
+      return;
+    }
+    
+    setIsLoading(true);
+    setMessage('');
+    
+    try {
+      const response = await fetch('/api/seed-sample-data', {
+        method: 'DELETE',
+      });
+      
+      const result = await response.json();
+      
+      if (result.success) {
+        setMessage(`✅ ${result.message}`);
+      } else {
+        setMessage(`❌ エラー: ${result.message}`);
+      }
+    } catch (error) {
+      setMessage(`❌ 通信エラー: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">管理者ページ</h1>
+        
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 space-y-6">
+          <h2 className="text-xl font-semibold text-gray-900">データ管理</h2>
+          
+          <div className="space-y-4">
+            <div>
+              <button
+                onClick={seedSampleData}
+                disabled={isLoading}
+                className="px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed mr-4"
+              >
+                {isLoading ? '作成中...' : '正式サービス名でサンプルデータ作成'}
+              </button>
+              
+              <button
+                onClick={deleteAllData}
+                disabled={isLoading}
+                className="px-6 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 disabled:opacity-50"
+              >
+                {isLoading ? '削除中...' : '全セッションデータ削除'}
+              </button>
+            </div>
+            
+            {message && (
+              <div className="p-4 rounded-lg bg-gray-100 text-gray-800 font-mono text-sm">
+                {message}
+              </div>
+            )}
+          </div>
+          
+          <div className="border-t pt-4">
+            <h3 className="font-medium text-gray-900 mb-2">操作手順</h3>
+            <ol className="list-decimal list-inside text-sm text-gray-600 space-y-1">
+              <li>まず「全セッションデータ削除」で古いデータを削除</li>
+              <li>「正式サービス名でサンプルデータ作成」で新しいデータを作成</li>
+              <li>ダッシュボードに戻って表示を確認</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/lp-validation/src/app/api/campaigns-mapping/route.ts
+++ b/apps/lp-validation/src/app/api/campaigns-mapping/route.ts
@@ -62,17 +62,17 @@ export async function GET(req: NextRequest) {
       const campaignNameLower = name.toLowerCase()
       
       if (campaignNameLower.includes('watashi') || campaignNameLower.includes('わたし') || campaignNameLower.includes('compass')) {
-        productName = 'WATASHI-COMPASS'
+        productName = 'わたしコンパス'
       } else if (campaignNameLower.includes('ai-bridge') || campaignNameLower.includes('bridge')) {
-        productName = 'AI-BRIDGE'
+        productName = '世代bridge'
       } else if (campaignNameLower.includes('ai-coach') || campaignNameLower.includes('coach')) {
-        productName = 'AI-COACH'
+        productName = 'じぶん lab'
       } else if (campaignNameLower.includes('ai-stylist') || campaignNameLower.includes('stylist')) {
-        productName = 'AI-STYLIST'
+        productName = 'きこなし'
       } else if (campaignNameLower.includes('mywa')) {
         productName = 'MYWA'
       } else if (campaignNameLower.includes('legacy') || campaignNameLower.includes('creator')) {
-        productName = 'AI-LEGACY-CREATOR'
+        productName = '想い帳'
       }
       
       // メトリクス計算

--- a/apps/lp-validation/src/app/api/migrate-product-names/route.ts
+++ b/apps/lp-validation/src/app/api/migrate-product-names/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '../../../../../../convex/_generated/api'
+
+// Read env at runtime using bracket notation to avoid compile-time inlining
+function env(key: string): string {
+  try {
+    // @ts-ignore
+    return (process.env && (process.env as any)[key]) || ''
+  } catch {
+    return ''
+  }
+}
+
+const DEFAULT_WORKSPACE = env('NEXT_PUBLIC_DEFAULT_WORKSPACE_ID') || 'unson_main'
+
+function resolveConvexUrl(): string {
+  const val = (env('NEXT_PUBLIC_CONVEX_URL') || env('CONVEX_URL') || '').trim()
+  const dep = (env('CONVEX_DEPLOYMENT') || '').trim()
+  // Prefer explicit URL when provided and not default
+  if (val && val !== 'default') return val
+  // If convex dev is running (dev:xxxx) or URL is default, use local dev server
+  if (val === 'default' || dep.startsWith('dev:') || dep === 'default') {
+    return 'http://127.0.0.1:3210'
+  }
+  throw new Error('Convex URL is not configured')
+}
+
+function client() {
+  return new ConvexHttpClient(resolveConvexUrl())
+}
+
+// サービス名マッピング
+const SERVICE_NAME_MAPPING = {
+  'AI-BRIDGE': '世代bridge',
+  'AI世代間ブリッジ': '世代bridge',
+  'AI-COACH': 'じぶん lab',
+  'AI自分時間コーチ': 'じぶん lab',
+  'AI-STYLIST': 'きこなし',
+  'AIパーソナルスタイリスト': 'きこなし',
+  'AI-LEGACY-CREATOR': '想い帳',
+  'AIレガシー・クリエーター': '想い帳',
+  'WATASHI-COMPASS': 'わたしコンパス'
+}
+
+export async function POST() {
+  try {
+    const c = client()
+    
+    // 既存セッションを取得
+    const sessions = await c.query(api.lpValidation.getActiveSessionsByWorkspace, { 
+      workspaceId: DEFAULT_WORKSPACE 
+    })
+    
+    console.log(`移行対象セッション数: ${sessions.length}`)
+    
+    let updateCount = 0
+    
+    for (const session of sessions) {
+      const oldName = session.product_name
+      const newName = SERVICE_NAME_MAPPING[oldName as keyof typeof SERVICE_NAME_MAPPING]
+      
+      if (newName && newName !== oldName) {
+        // 製品名を更新
+        await c.mutation(api.lpValidation.updateProductName, {
+          sessionId: session._id,
+          newProductName: newName
+        })
+        
+        console.log(`更新: ${oldName} → ${newName}`)
+        updateCount++
+      }
+    }
+    
+    return NextResponse.json({
+      success: true,
+      message: `${updateCount}件のサービス名を更新しました`,
+      updated: updateCount,
+      total: sessions.length
+    })
+    
+  } catch (error: any) {
+    console.error('サービス名移行エラー:', error)
+    return NextResponse.json({
+      success: false,
+      error: error.message,
+      message: 'サービス名の移行に失敗しました'
+    }, { status: 500 })
+  }
+}

--- a/apps/lp-validation/src/app/api/seed-sample-data/route.ts
+++ b/apps/lp-validation/src/app/api/seed-sample-data/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '../../../../../../convex/_generated/api'
+
+// Read env at runtime using bracket notation to avoid compile-time inlining
+function env(key: string): string {
+  try {
+    // @ts-ignore
+    return (process.env && (process.env as any)[key]) || ''
+  } catch {
+    return ''
+  }
+}
+
+const DEFAULT_WORKSPACE = env('NEXT_PUBLIC_DEFAULT_WORKSPACE_ID') || 'unson_main'
+
+function resolveConvexUrl(): string {
+  const val = (env('NEXT_PUBLIC_CONVEX_URL') || env('CONVEX_URL') || '').trim()
+  const dep = (env('CONVEX_DEPLOYMENT') || '').trim()
+  // Prefer explicit URL when provided and not default
+  if (val && val !== 'default') return val
+  // If convex dev is running (dev:xxxx) or URL is default, use local dev server
+  if (val === 'default' || dep.startsWith('dev:') || dep === 'default') {
+    return 'http://127.0.0.1:3210'
+  }
+  throw new Error('Convex URL is not configured')
+}
+
+function client() {
+  return new ConvexHttpClient(resolveConvexUrl())
+}
+
+// 正式サービス名のサンプルデータ
+const sampleSessions = [
+  {
+    id: '2025-08-002-ai-bridge',
+    name: '世代bridge',
+    lpUrl: 'https://unson-lp-ai-bridge.vercel.app',
+    status: 'active' as const,
+    targetCvr: 10.0,
+    targetCpa: 3980,
+    minSessions: 1000,
+    playbookId: 'PB-001'
+  },
+  {
+    id: '2025-08-003-ai-coach',
+    name: 'じぶん lab',
+    lpUrl: 'https://unson-lp-ai-coach.vercel.app',
+    status: 'active' as const,
+    targetCvr: 12.0,
+    targetCpa: 2980,
+    minSessions: 1000,
+    playbookId: 'PB-001'
+  },
+  {
+    id: '2025-08-005-ai-stylist',
+    name: 'きこなし',
+    lpUrl: 'https://unson-lp-ai-stylist.vercel.app',
+    status: 'active' as const,
+    targetCvr: 15.0,
+    targetCpa: 4980,
+    minSessions: 1000,
+    playbookId: 'PB-001'
+  },
+  {
+    id: '2025-08-004-ai-legacy-creator',
+    name: '想い帳',
+    lpUrl: 'https://unson-lp-ai-legacy-creator.vercel.app',
+    status: 'active' as const,
+    targetCvr: 8.0,
+    targetCpa: 19800,
+    minSessions: 500,
+    playbookId: 'PB-001'
+  },
+  {
+    id: '2025-08-006-watashi-compass',
+    name: 'わたしコンパス',
+    lpUrl: 'https://unson-lp-watashi-compass.vercel.app',
+    status: 'active' as const,
+    targetCvr: 10.0,
+    targetCpa: 5000,
+    minSessions: 1000,
+    playbookId: 'PB-001'
+  },
+  {
+    id: '2025-08-001-mywa',
+    name: 'MYWA',
+    lpUrl: 'https://unson-lp-mywa.vercel.app',
+    status: 'active' as const,
+    targetCvr: 20.0,
+    targetCpa: 2000,
+    minSessions: 2000,
+    playbookId: 'PB-001'
+  }
+]
+
+export async function POST() {
+  try {
+    const c = client()
+    
+    console.log('正式サービス名でサンプルデータを作成中...')
+    
+    let createdCount = 0
+    
+    for (const session of sampleSessions) {
+      try {
+        // 既存セッションがあるかチェック（product_idで）
+        const existingSessions = await c.query(api.lpValidation.getSessionsByProduct, { 
+          productId: session.id,
+          limit: 1
+        })
+        
+        if (existingSessions.length > 0) {
+          console.log(`${session.name} は既に存在するためスキップ`)
+          continue
+        }
+        
+        // セッション作成
+        await c.mutation(api.lpValidation.createSession, {
+          workspace_id: DEFAULT_WORKSPACE,
+          product_id: session.id,
+          product_name: session.name,
+          lp_url: session.lpUrl,
+          status: session.status,
+          target_cvr: session.targetCvr,
+          target_cpa: session.targetCpa,
+          min_sessions: session.minSessions,
+          automation_enabled: true,
+          auto_optimization: true,
+          auto_deployment: false,
+          current_playbook_id: session.playbookId,
+          created_by: 'sample-data-seeder'
+        })
+        
+        console.log(`✅ ${session.name} セッション作成完了`)
+        createdCount++
+        
+      } catch (error) {
+        console.error(`${session.name} 作成エラー:`, error)
+      }
+    }
+    
+    return NextResponse.json({
+      success: true,
+      message: `${createdCount}件の正式サービス名サンプルデータを作成しました`,
+      created: createdCount,
+      total: sampleSessions.length
+    })
+    
+  } catch (error: any) {
+    console.error('サンプルデータ作成エラー:', error)
+    return NextResponse.json({
+      success: false,
+      error: error.message,
+      message: 'サンプルデータの作成に失敗しました'
+    }, { status: 500 })
+  }
+}
+
+// 古いデータを削除する機能
+export async function DELETE() {
+  try {
+    const c = client()
+    
+    // 全アクティブセッション取得
+    const sessions = await c.query(api.lpValidation.getActiveSessionsByWorkspace, {
+      workspaceId: DEFAULT_WORKSPACE
+    })
+    
+    console.log(`削除対象セッション数: ${sessions.length}`)
+    
+    let deletedCount = 0
+    
+    for (const session of sessions) {
+      await c.mutation(api.lpValidation.deleteSession, {
+        sessionId: session._id
+      })
+      deletedCount++
+    }
+    
+    return NextResponse.json({
+      success: true,
+      message: `${deletedCount}件のセッションを削除しました`,
+      deleted: deletedCount
+    })
+    
+  } catch (error: any) {
+    console.error('データ削除エラー:', error)
+    return NextResponse.json({
+      success: false,
+      error: error.message,
+      message: 'データの削除に失敗しました'
+    }, { status: 500 })
+  }
+}

--- a/apps/lp-validation/src/app/event/[id]/page.tsx
+++ b/apps/lp-validation/src/app/event/[id]/page.tsx
@@ -20,7 +20,7 @@ export default function EventDetailPage() {
     time: '15:30',
     date: '2025/08/22',
     sessionId: 'ai-coach-001',
-    positionName: 'AI-COACH',
+    positionName: 'じぶん lab',
     type: 'optimization',
     status: 'completed',
     metrics: {

--- a/apps/lp-validation/src/app/page.tsx
+++ b/apps/lp-validation/src/app/page.tsx
@@ -97,6 +97,23 @@ export default function DashboardPage() {
     return position // 該当データなし、または取得失敗時は元のデータを返す
   }
 
+  // 古いサービス名を正式名にマッピング
+  const mapServiceName = (oldName: string) => {
+    const nameMapping: Record<string, string> = {
+      'AI-BRIDGE': '世代bridge',
+      'AI世代間ブリッジ': '世代bridge',
+      'AI-COACH': 'じぶん lab',
+      'AI自分時間コーチ': 'じぶん lab',
+      'AI-STYLIST': 'きこなし',
+      'AIパーソナルスタイリスト': 'きこなし',
+      'AI-LEGACY-CREATOR': '想い帳',
+      'AIレガシー・クリエーター': '想い帳',
+      'WATASHI-COMPASS': 'わたしコンパス',
+      'MYWA': 'MYWA'
+    }
+    return nameMapping[oldName] || oldName
+  }
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -105,9 +122,15 @@ export default function DashboardPage() {
           const data = await res.json()
           const basePositions = data.positions || []
           
+          // サービス名を正式名にマッピング
+          const mappedPositions = basePositions.map((position: any) => ({
+            ...position,
+            name: mapServiceName(position.name)
+          }))
+          
           // 各ポジションに実データを統合
           const enrichedPositions = await Promise.all(
-            basePositions.map(enrichPositionWithRealData)
+            mappedPositions.map(enrichPositionWithRealData)
           )
           
           setPositions(enrichedPositions)

--- a/convex/lpValidation.ts
+++ b/convex/lpValidation.ts
@@ -226,3 +226,17 @@ export const deleteSession = mutation({
     await ctx.db.delete(args.sessionId);
   },
 });
+
+// 製品名更新（サービス名移行用）
+export const updateProductName = mutation({
+  args: {
+    sessionId: v.id("lpValidationSessions"),
+    newProductName: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.sessionId, {
+      product_name: args.newProductName,
+      updated_at: Date.now(),
+    });
+  },
+});

--- a/products/2-validation/2025-08-002-ai-bridge/product.yaml
+++ b/products/2-validation/2025-08-002-ai-bridge/product.yaml
@@ -2,7 +2,7 @@
 
 # 基本情報
 productId: "2025-08-002-ai-bridge"
-name: "AI世代間ブリッジ"
+name: "世代bridge"
 slug: "ai-bridge"
 category: "ビジネス"
 

--- a/products/2-validation/2025-08-003-ai-coach/product.yaml
+++ b/products/2-validation/2025-08-003-ai-coach/product.yaml
@@ -2,7 +2,7 @@
 
 # 基本情報
 productId: "2025-08-003-ai-coach"
-name: "AI自分時間コーチ"
+name: "じぶん lab"
 slug: "ai-coach"
 category: "ライフスタイル"
 

--- a/products/2-validation/2025-08-004-ai-legacy-creator/product.yaml
+++ b/products/2-validation/2025-08-004-ai-legacy-creator/product.yaml
@@ -2,7 +2,7 @@
 
 # 基本情報
 productId: "2025-08-004-ai-legacy-creator"
-name: "AIレガシー・クリエーター"
+name: "想い帳"
 slug: "ai-legacy-creator"
 category: "ファミリー"
 

--- a/products/2-validation/2025-08-005-ai-stylist/product.yaml
+++ b/products/2-validation/2025-08-005-ai-stylist/product.yaml
@@ -2,7 +2,7 @@
 
 # 基本情報
 productId: "2025-08-005-ai-stylist"
-name: "AIパーソナルスタイリスト"
+name: "きこなし"
 slug: "ai-stylist"
 category: "ファッション"
 


### PR DESCRIPTION
## Summary
コピーライティング原則に基づき、全サービス名を実際のユーザーが使いたくなる正式名に統一しました。

### 🎯 サービス名変更
- **AI世代間ブリッジ** → **世代bridge** (40代管理職向け)
- **AI自分時間コーチ** → **じぶん lab** (20-30代向け)  
- **AIパーソナルスタイリスト** → **きこなし** (20-40代女性向け)
- **AIレガシー・クリエーター** → **想い帳** (50-60代向け)
- **WATASHI-COMPASS** → **わたしコンパス**

### 📝 主な変更内容
#### 1. Product Definition (product.yaml)
- 各プロダクトのnameフィールドを正式サービス名に更新
- ユーザーペルソナに適した文字面（ひらがな・漢字・英語）を採用

#### 2. フロントエンド表示統一
- ダッシュボードでサービス名の自動マッピング機能追加 (`src/app/page.tsx`)
- Google Adsキャンペーン連携で正式名使用 (`src/app/api/campaigns-mapping/route.ts`)
- イベント詳細画面のサービス名更新

#### 3. テスト環境対応
- 全テストケースのサービス名を正式名に更新
- テストの期待値を新しいサービス名に合わせて修正

#### 4. データベース移行機能
- Convexセッションデータ移行API (`src/app/api/migrate-product-names/route.ts`)
- 管理者ページでデータ管理機能 (`src/app/admin/page.tsx`)
- サンプルデータ作成機能 (`src/app/api/seed-sample-data/route.ts`)

### 🧠 設計思想
**「ユーザーの本音重視」**
- 職場で堂々と言える名前
- SNSで自慢できる響き
- サービス内容が直感的にわかる
- 世代に応じた親しみやすさ

### Test plan
- [x] ダッシュボードで正式サービス名表示確認
- [x] Google Adsキャンペーンデータとの連携確認
- [x] 既存テストの全通過確認
- [ ] 本番環境でのデータ移行テスト

🤖 Generated with [Claude Code](https://claude.ai/code)