### PR TITLE
feat(lp-suite): add AI employee intake dry-run

### DIFF
--- a/apps/lp-suite/src/app/api/ai-employee-diagnosis/intake/__tests__/route.test.ts
+++ b/apps/lp-suite/src/app/api/ai-employee-diagnosis/intake/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { POST } from '../route';
+
+const payload = {
+  submitted_at: '2026-04-26T00:00:00.000Z',
+  form_variant: 'diagnosis_v1',
+  landing_page: '/ai-employee-diagnosis',
+  attribution: {
+    utm_source: 'x',
+    utm_medium: 'paid_social',
+    utm_campaign: 'ai_driven_management_202604',
+    keyword_family: 'ai_employee',
+  },
+  company: {
+    name: '株式会社サンプル',
+    size: '51-200',
+  },
+  contact: {
+    name: '山田 太郎',
+    email: 'taro@example.com',
+  },
+  diagnosis: {
+    target_function: 'sales',
+    pain: '議事録とCRM更新が属人化している',
+    urgency: 'this_quarter',
+    budget_signal: 'unknown',
+    authority_signal: 'medium',
+  },
+  consent: {
+    privacy_policy: true,
+  },
+};
+
+describe('POST /api/ai-employee-diagnosis/intake', () => {
+  it('returns dry-run payload when dryRun=true', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/intake?dryRun=true', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.dry_run).toBe(true);
+    expect(body.write_plan).toContain('graph.push_case.upsert');
+    expect(body.nocodb_projection.fields.brainbase_push_case_id).toBe(body.ids.brainbase_push_case_id);
+  });
+
+  it('rejects real writes until Graph/PostHog/NocoDB clients are implemented', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/intake', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Only dryRun=true is implemented');
+  });
+
+  it('returns validation errors for malformed JSON', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/intake?dryRun=true', {
+        method: 'POST',
+        body: '{',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.validation.errors[0].code).toBe('invalid_json');
+    expect(body.write_plan).toEqual([]);
+  });
+});

--- a/apps/lp-suite/src/app/api/ai-employee-diagnosis/intake/route.ts
+++ b/apps/lp-suite/src/app/api/ai-employee-diagnosis/intake/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+import { buildIntakeDryRun } from '@/lib/ai-employee-intake/transform';
+import type { AiEmployeeIntakeRequest } from '@/lib/ai-employee-intake/types';
+
+export async function POST(request: Request) {
+  const url = new URL(request.url);
+  const dryRun = url.searchParams.get('dryRun') === 'true';
+
+  if (!dryRun) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Only dryRun=true is implemented. Real Graph/PostHog/NocoDB writes are intentionally disabled.',
+      },
+      { status: 501 },
+    );
+  }
+
+  try {
+    const body = (await request.json()) as AiEmployeeIntakeRequest;
+    const response = buildIntakeDryRun(body);
+
+    return NextResponse.json(response, { status: response.ok ? 200 : 400 });
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        dry_run: true,
+        validation: {
+          valid: false,
+          errors: [
+            {
+              code: 'invalid_json',
+              message: 'Request body must be valid JSON.',
+              severity: 'error',
+            },
+          ],
+          warnings: [],
+        },
+        write_plan: [],
+        graph: {
+          entities: [],
+          edges: [],
+        },
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/lp-suite/src/app/position/[id]/utils/eventIntegration.ts
+++ b/apps/lp-suite/src/app/position/[id]/utils/eventIntegration.ts
@@ -7,6 +7,11 @@ export interface EventLog {
   cvr?: number
   sessions?: number
   cpl?: number
+  ctr?: number
+  cpc?: number
+  ctrRating?: 'good' | 'average' | 'poor'
+  cvrRating?: 'good' | 'average' | 'poor'
+  performanceEmoji?: string
   optimization: string
   ai: string
   // Google Ads specific
@@ -75,8 +80,9 @@ export function formatGoogleAdsEvent(ads: AdsData): EventLog {
 
 // ベタ書きでイベントログとGoogle Ads実績を時系列マージ
 export function mergeEventsAndAds(events: any[], adsData: AdsData[]): EventLog[] {
-  const eventLogs = events.map((e, index) => ({
+  const eventLogs: EventLog[] = events.map((e, index) => ({
     time: e.time,
+    sortTime: e.sortTime || e.timestamp || e.time,
     type: 'event' as const,
     cvr: 0,
     sessions: 0, 

--- a/apps/lp-suite/src/lib/ai-employee-intake/__tests__/transform.test.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/__tests__/transform.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildIntakeDryRun } from '../transform';
+import type { AiEmployeeIntakeRequest } from '../types';
+
+const validRequest: AiEmployeeIntakeRequest = {
+  submitted_at: '2026-04-26T00:00:00.000Z',
+  form_variant: 'diagnosis_v1',
+  landing_page: '/ai-employee-diagnosis',
+  referrer: 'https://x.com/',
+  attribution: {
+    utm_source: 'x',
+    utm_medium: 'paid_social',
+    utm_campaign: 'ai_driven_management_202604',
+    utm_content: 'hero_a',
+    utm_term: 'ai_employee',
+    keyword_family: 'ai_employee',
+    click_ids: {
+      xclid: 'x_123',
+      fbclid: null,
+      gclid: null,
+    },
+  },
+  company: {
+    name: '株式会社サンプル',
+    website: 'https://example.com',
+    size: '51-200',
+    industry: 'software',
+  },
+  contact: {
+    name: '山田 太郎',
+    email: 'TARO@example.com',
+    phone: '',
+    department: '事業開発',
+    role: '事業責任者',
+  },
+  diagnosis: {
+    target_function: 'sales',
+    ai_adoption_stage: 'trial',
+    pain: '議事録とCRM更新が属人化している',
+    urgency: 'this_quarter',
+    budget_signal: 'unknown',
+    authority_signal: 'medium',
+    free_text: '営業チームの商談後処理をAI化したい',
+  },
+  consent: {
+    privacy_policy: true,
+    marketing_contact: true,
+  },
+};
+
+describe('buildIntakeDryRun', () => {
+  it('valid request creates Graph/PostHog/NocoDB write plans without writing', () => {
+    const result = buildIntakeDryRun(validRequest);
+
+    expect(result.ok).toBe(true);
+    expect(result.dry_run).toBe(true);
+    expect(result.validation.valid).toBe(true);
+    expect(result.write_plan).toEqual([
+      'graph.customer.upsert',
+      'graph.contact.upsert',
+      'graph.push_case.upsert',
+      'graph.diagnosis.upsert',
+      'graph.edges.upsert',
+      'posthog.capture',
+      'nocodb.push_case_projection.upsert',
+    ]);
+    expect(result.graph.entities.map((entity) => entity.entityType)).toEqual([
+      'customer',
+      'contact',
+      'push_case',
+      'diagnosis',
+    ]);
+    expect(result.posthog?.event).toBe('diagnosis_form_submit');
+    expect(result.nocodb_projection?.tableName).toBe('推進案件');
+  });
+
+  it('push_case is the CRM center and carries governance philosophy ids', () => {
+    const result = buildIntakeDryRun(validRequest);
+    const pushCase = result.graph.entities.find((entity) => entity.entityType === 'push_case');
+
+    expect(pushCase?.payload.customer_id).toBe(result.ids?.brainbase_customer_id);
+    expect(pushCase?.payload.primary_contact_id).toBe(result.ids?.brainbase_contact_id);
+    expect(pushCase?.payload.stage).toBe('diagnosis_submitted');
+    expect(pushCase?.payload.philosophy_ids).toEqual([
+      'phi_push_case_center',
+      'phi_ui_is_projection',
+      'phi_data_ownership_by_use',
+      'phi_learning_loop',
+    ]);
+    expect(result.graph.edges.filter((edge) => edge.relType === 'governed_by')).toHaveLength(4);
+  });
+
+  it('NocoDB projection remains a projection and includes Brainbase IDs', () => {
+    const result = buildIntakeDryRun(validRequest);
+
+    expect(result.nocodb_projection?.fields).toMatchObject({
+      案件名: '株式会社サンプル AI社員化PoC提案',
+      顧客名: '株式会社サンプル',
+      ステータス: 'リード',
+      角度: '★☆☆☆☆ (10%)',
+      brainbase_push_case_id: result.ids?.brainbase_push_case_id,
+      brainbase_customer_id: result.ids?.brainbase_customer_id,
+      brainbase_contact_id: result.ids?.brainbase_contact_id,
+      diagnosis_id: result.ids?.diagnosis_id,
+    });
+  });
+
+  it('invalid request returns no write plan and no side-effect payloads', () => {
+    const result = buildIntakeDryRun({
+      ...validRequest,
+      contact: {
+        ...validRequest.contact,
+        email: '',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.validation.valid).toBe(false);
+    expect(result.validation.errors.map((issue) => issue.code)).toContain('missing_contact_email');
+    expect(result.write_plan).toEqual([]);
+    expect(result.graph.entities).toEqual([]);
+    expect(result.graph.edges).toEqual([]);
+    expect(result.posthog).toBeUndefined();
+    expect(result.nocodb_projection).toBeUndefined();
+  });
+});

--- a/apps/lp-suite/src/lib/ai-employee-intake/ids.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/ids.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'crypto';
+
+import type { AiEmployeeIntakeRequest, DedupePlan, IntakeStableIds } from './types';
+
+const OFFER_FAMILY = 'diagnosis';
+
+export function normalizeCompanyName(value: string | undefined): string {
+  return (value || '').trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeEmail(value: string | undefined): string {
+  return (value || '').trim().toLowerCase();
+}
+
+function hash10(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 10);
+}
+
+export function buildStableIds(input: AiEmployeeIntakeRequest): IntakeStableIds {
+  const companyName = normalizeCompanyName(input.company?.name);
+  const email = normalizeEmail(input.contact?.email);
+  const submittedAt = (input.submitted_at || '').trim();
+
+  const customerHash = hash10(companyName);
+  const contactHash = hash10(email);
+  const pushCaseHash = hash10(`${companyName}:${email}:${OFFER_FAMILY}`);
+  const diagnosisHash = hash10(`pc_ai_employee_${pushCaseHash}:${submittedAt}`);
+
+  return {
+    brainbase_customer_id: `cus_ai_employee_${customerHash}`,
+    brainbase_contact_id: `con_ai_employee_${contactHash}`,
+    brainbase_push_case_id: `pc_ai_employee_${pushCaseHash}`,
+    diagnosis_id: `diag_ai_employee_${diagnosisHash}`,
+  };
+}
+
+export function buildDedupePlan(input: AiEmployeeIntakeRequest, ids: IntakeStableIds): DedupePlan {
+  const companyName = normalizeCompanyName(input.company?.name);
+  const email = normalizeEmail(input.contact?.email);
+
+  return {
+    customer: {
+      key: `company_name:${companyName}`,
+      id: ids.brainbase_customer_id,
+      action: 'upsert',
+    },
+    contact: {
+      key: `email:${email}`,
+      id: ids.brainbase_contact_id,
+      action: 'upsert',
+    },
+    push_case: {
+      key: `${companyName}:${email}:${OFFER_FAMILY}`,
+      id: ids.brainbase_push_case_id,
+      action: 'upsert',
+    },
+    diagnosis: {
+      key: `${ids.brainbase_push_case_id}:${(input.submitted_at || '').trim()}`,
+      id: ids.diagnosis_id,
+      action: 'create',
+    },
+  };
+}

--- a/apps/lp-suite/src/lib/ai-employee-intake/stage-mapping.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/stage-mapping.ts
@@ -1,0 +1,24 @@
+export function mapPushCaseStageToNocoStatus(stage: string): string {
+  const mapping: Record<string, string> = {
+    diagnosis_submitted: 'リード',
+    booked: '初回接触',
+    discovery: 'ヒアリング',
+    qualified: 'ヒアリング',
+    proposed: '提案済み',
+    negotiating: '商談中',
+    won: '受注',
+    lost: '失注',
+    recycled: '保留',
+    paused: '保留',
+  };
+
+  return mapping[stage] || 'リード';
+}
+
+export function mapProbabilityToNocoAngle(probability: number): string {
+  if (probability >= 0.95) return '★★★★★ (95%)';
+  if (probability >= 0.75) return '★★★★☆ (75%)';
+  if (probability >= 0.5) return '★★★☆☆ (50%)';
+  if (probability >= 0.3) return '★★☆☆☆ (30%)';
+  return '★☆☆☆☆ (10%)';
+}

--- a/apps/lp-suite/src/lib/ai-employee-intake/transform.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/transform.ts
@@ -1,0 +1,323 @@
+import { buildDedupePlan, buildStableIds, normalizeCompanyName, normalizeEmail } from './ids';
+import { mapProbabilityToNocoAngle, mapPushCaseStageToNocoStatus } from './stage-mapping';
+import type {
+  AiEmployeeIntakeRequest,
+  GraphEdge,
+  GraphEntity,
+  IntakeDryRunResponse,
+  IntakeStableIds,
+  NocoDbProjectionPlan,
+  PostHogCapturePlan,
+} from './types';
+import { validateIntake } from './validate';
+
+const PHILOSOPHY_IDS = [
+  'phi_push_case_center',
+  'phi_ui_is_projection',
+  'phi_data_ownership_by_use',
+  'phi_learning_loop',
+];
+
+const WRITE_PLAN = [
+  'graph.customer.upsert',
+  'graph.contact.upsert',
+  'graph.push_case.upsert',
+  'graph.diagnosis.upsert',
+  'graph.edges.upsert',
+  'posthog.capture',
+  'nocodb.push_case_projection.upsert',
+];
+
+function sourceChannel(utmSource?: string | null): string {
+  if (utmSource === 'x') return 'x_ads';
+  if (utmSource === 'meta' || utmSource === 'facebook' || utmSource === 'instagram') return 'meta_ads';
+  if (utmSource === 'google') return 'google_ads';
+  return 'inbound_form';
+}
+
+function buildGraphEntities(input: AiEmployeeIntakeRequest, ids: IntakeStableIds): GraphEntity[] {
+  const companyName = normalizeCompanyName(input.company?.name);
+  const email = normalizeEmail(input.contact?.email);
+  const submittedAt = input.submitted_at || new Date().toISOString();
+  const title = `${companyName} AI社員化PoC提案`;
+  const stage = 'diagnosis_submitted';
+  const probability = 0.1;
+
+  const customer: GraphEntity = {
+    id: ids.brainbase_customer_id,
+    entityType: 'customer',
+    projectCode: 'unson',
+    projectName: 'Unson',
+    roleMin: 'gm',
+    sensitivity: 'restricted',
+    payload: {
+      customer_id: ids.brainbase_customer_id,
+      name: companyName,
+      website: input.company?.website || '',
+      company_size: input.company?.size || '',
+      industry: input.company?.industry || '',
+      status: 'prospect',
+      projects: ['ai-employee-adoption'],
+      source: 'ai_employee_diagnosis',
+      lead_source: {
+        utm_source: input.attribution?.utm_source || null,
+        utm_medium: input.attribution?.utm_medium || null,
+        utm_campaign: input.attribution?.utm_campaign || null,
+        utm_content: input.attribution?.utm_content || null,
+        utm_term: input.attribution?.utm_term || null,
+        keyword_family: input.attribution?.keyword_family || null,
+        offer: 'diagnosis',
+      },
+      created_or_updated_from: 'ai_employee_diagnosis_intake',
+      last_intake_at: submittedAt,
+    },
+  };
+
+  const contact: GraphEntity = {
+    id: ids.brainbase_contact_id,
+    entityType: 'contact',
+    projectCode: 'unson',
+    projectName: 'Unson',
+    roleMin: 'gm',
+    sensitivity: 'restricted',
+    payload: {
+      contact_id: ids.brainbase_contact_id,
+      name: input.contact?.name || '',
+      email,
+      phone: input.contact?.phone || '',
+      company: companyName,
+      company_id: ids.brainbase_customer_id,
+      department: input.contact?.department || '',
+      role: input.contact?.role || '',
+      projects: ['ai-employee-adoption'],
+      source: 'ai_employee_diagnosis',
+      last_intake_at: submittedAt,
+    },
+  };
+
+  const pushCase: GraphEntity = {
+    id: ids.brainbase_push_case_id,
+    entityType: 'push_case',
+    projectCode: 'unson',
+    projectName: 'Unson',
+    roleMin: 'gm',
+    sensitivity: 'restricted',
+    payload: {
+      push_case_id: ids.brainbase_push_case_id,
+      title,
+      display_name: `${companyName} / AI社員化PoC`,
+      customer_id: ids.brainbase_customer_id,
+      primary_contact_id: ids.brainbase_contact_id,
+      owner_person_id: 'per_keigo_sato',
+      project_code: 'unson',
+      stage,
+      stage_reason: 'AI社員化診断フォーム送信により作成',
+      value_hypothesis: `${input.diagnosis?.pain || ''}領域をAI社員化できる`,
+      offer_family: 'diagnosis',
+      source: {
+        source_type: 'inbound_form',
+        channel: sourceChannel(input.attribution?.utm_source),
+        utm_source: input.attribution?.utm_source || null,
+        utm_medium: input.attribution?.utm_medium || null,
+        utm_campaign: input.attribution?.utm_campaign || null,
+        utm_content: input.attribution?.utm_content || null,
+        utm_term: input.attribution?.utm_term || null,
+        keyword_family: input.attribution?.keyword_family || null,
+        landing_page: input.landing_page || null,
+        referrer: input.referrer || null,
+        click_ids: input.attribution?.click_ids || {},
+      },
+      next_action: {
+        label: '診断日程を確定する',
+        owner_person_id: 'per_keigo_sato',
+        due_at: null,
+        ball_holder: 'unson',
+        status: 'open',
+      },
+      forecast: {
+        expected_value_jpy: null,
+        expected_value_confidence: 'unknown',
+        expected_timing: 'unknown',
+        probability,
+      },
+      qualification: {
+        company_size: input.company?.size || '',
+        target_function: input.diagnosis?.target_function || '',
+        urgency: input.diagnosis?.urgency || '',
+        budget_signal: input.diagnosis?.budget_signal || 'unknown',
+        authority_signal: input.diagnosis?.authority_signal || 'unknown',
+        need_signal: 'medium',
+        timing_signal: input.diagnosis?.urgency === 'this_quarter' ? 'high' : 'medium',
+        fit_score: null,
+        qualified_reason: null,
+      },
+      control_state: {
+        execution_health: 'normal',
+        evidence_state: 'missing',
+        approval_state: 'not_required',
+        escalation_state: 'none',
+        attention_level: 'watch',
+        blocked_reason: null,
+        missing_evidence: ['診断回答', '導入対象業務', '決裁関与者'],
+        last_decision_record_id: null,
+      },
+      philosophy_ids: PHILOSOPHY_IDS,
+      refs: {
+        diagnosis_ids: [ids.diagnosis_id],
+        initiative_ids: [],
+        story_ids: [],
+        decision_item_ids: [],
+        decision_record_ids: [],
+        communication_ids: [],
+        evidence_ref_ids: [],
+        task_refs: [],
+        ship_refs: [],
+        nocodb_sales_record: null,
+      },
+      created_at: submittedAt,
+      updated_at: submittedAt,
+    },
+  };
+
+  const diagnosis: GraphEntity = {
+    id: ids.diagnosis_id,
+    entityType: 'diagnosis',
+    projectCode: 'unson',
+    projectName: 'Unson',
+    roleMin: 'gm',
+    sensitivity: 'restricted',
+    payload: {
+      diagnosis_id: ids.diagnosis_id,
+      push_case_id: ids.brainbase_push_case_id,
+      customer_id: ids.brainbase_customer_id,
+      contact_id: ids.brainbase_contact_id,
+      status: 'submitted',
+      submitted_at: submittedAt,
+      form_variant: input.form_variant || 'diagnosis_v1',
+      answers: {
+        target_function: input.diagnosis?.target_function || '',
+        ai_adoption_stage: input.diagnosis?.ai_adoption_stage || '',
+        pain: input.diagnosis?.pain || '',
+        urgency: input.diagnosis?.urgency || '',
+        budget_signal: input.diagnosis?.budget_signal || 'unknown',
+        authority_signal: input.diagnosis?.authority_signal || 'unknown',
+        free_text: input.diagnosis?.free_text || '',
+      },
+      fit_score: null,
+      analysis_refs: [],
+      decision_record_id: null,
+    },
+  };
+
+  return [customer, contact, pushCase, diagnosis];
+}
+
+function buildGraphEdges(ids: IntakeStableIds): GraphEdge[] {
+  return [
+    { fromId: ids.brainbase_customer_id, toId: ids.brainbase_push_case_id, relType: 'has_push_case' },
+    { fromId: ids.brainbase_contact_id, toId: ids.brainbase_push_case_id, relType: 'participates_in' },
+    { fromId: ids.brainbase_contact_id, toId: ids.brainbase_push_case_id, relType: 'primary_contact_for' },
+    { fromId: ids.brainbase_push_case_id, toId: ids.diagnosis_id, relType: 'has_diagnosis' },
+    { fromId: ids.diagnosis_id, toId: ids.brainbase_customer_id, relType: 'belongs_to_customer' },
+    ...PHILOSOPHY_IDS.map((philosophyId) => ({
+      fromId: ids.brainbase_push_case_id,
+      toId: philosophyId,
+      relType: 'governed_by' as const,
+    })),
+  ];
+}
+
+function buildPostHogPlan(input: AiEmployeeIntakeRequest, ids: IntakeStableIds): PostHogCapturePlan {
+  return {
+    event: 'diagnosis_form_submit',
+    distinct_id: ids.brainbase_contact_id,
+    timestamp: input.submitted_at || new Date().toISOString(),
+    properties: {
+      brainbase_customer_id: ids.brainbase_customer_id,
+      brainbase_contact_id: ids.brainbase_contact_id,
+      brainbase_push_case_id: ids.brainbase_push_case_id,
+      diagnosis_id: ids.diagnosis_id,
+      company_size: input.company?.size || '',
+      target_function: input.diagnosis?.target_function || '',
+      urgency: input.diagnosis?.urgency || '',
+      utm_source: input.attribution?.utm_source || null,
+      utm_medium: input.attribution?.utm_medium || null,
+      utm_campaign: input.attribution?.utm_campaign || null,
+      utm_content: input.attribution?.utm_content || null,
+      utm_term: input.attribution?.utm_term || null,
+      keyword_family: input.attribution?.keyword_family || null,
+      offer: 'diagnosis',
+      form_variant: input.form_variant || 'diagnosis_v1',
+      landing_page: input.landing_page || null,
+    },
+  };
+}
+
+function buildNocoDbProjection(input: AiEmployeeIntakeRequest, ids: IntakeStableIds): NocoDbProjectionPlan {
+  const companyName = normalizeCompanyName(input.company?.name);
+  const submittedDate = (input.submitted_at || '').slice(0, 10);
+  const stage = 'diagnosis_submitted';
+  const probability = 0.1;
+
+  return {
+    baseId: 'pipf5irgs2lzuon',
+    tableName: '推進案件',
+    fields: {
+      案件名: `${companyName} AI社員化PoC提案`,
+      顧客名: companyName,
+      ステータス: mapPushCaseStageToNocoStatus(stage),
+      角度: mapProbabilityToNocoAngle(probability),
+      '予算規模（万円）': null,
+      入金時期: '未定',
+      担当者: '佐藤圭吾',
+      初回接触日: submittedDate,
+      次アクション: '診断日程を確定する',
+      次アクション期限: null,
+      議事録リンク: null,
+      備考: `source=${input.attribution?.utm_source || 'unknown'} / campaign=${input.attribution?.utm_campaign || 'unknown'} / keyword_family=${input.attribution?.keyword_family || 'unknown'}`,
+      brainbase_push_case_id: ids.brainbase_push_case_id,
+      brainbase_customer_id: ids.brainbase_customer_id,
+      brainbase_contact_id: ids.brainbase_contact_id,
+      diagnosis_id: ids.diagnosis_id,
+      graph_url: `https://bb.unson.jp/graph/entities/${ids.brainbase_push_case_id}`,
+    },
+  };
+}
+
+export function buildIntakeDryRun(input: AiEmployeeIntakeRequest): IntakeDryRunResponse {
+  const validation = validateIntake(input);
+
+  if (!validation.valid) {
+    return {
+      ok: false,
+      dry_run: true,
+      validation,
+      write_plan: [],
+      graph: {
+        entities: [],
+        edges: [],
+      },
+    };
+  }
+
+  const ids = buildStableIds(input);
+  const dedupe = buildDedupePlan(input, ids);
+  const entities = buildGraphEntities(input, ids);
+  const edges = buildGraphEdges(ids);
+
+  return {
+    ok: true,
+    dry_run: true,
+    validation,
+    ids,
+    dedupe,
+    write_plan: WRITE_PLAN,
+    graph: {
+      entities,
+      edges,
+    },
+    posthog: buildPostHogPlan(input, ids),
+    nocodb_projection: buildNocoDbProjection(input, ids),
+    next: 'booking',
+  };
+}

--- a/apps/lp-suite/src/lib/ai-employee-intake/types.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/types.ts
@@ -1,0 +1,141 @@
+export type ValidationSeverity = 'error' | 'warning';
+
+export type ValidationIssue = {
+  code: string;
+  message: string;
+  severity: ValidationSeverity;
+  path?: string;
+};
+
+export type IntakeValidation = {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+};
+
+export type AiEmployeeIntakeRequest = {
+  submitted_at?: string;
+  form_variant?: string;
+  landing_page?: string;
+  referrer?: string;
+  attribution?: {
+    utm_source?: string | null;
+    utm_medium?: string | null;
+    utm_campaign?: string | null;
+    utm_content?: string | null;
+    utm_term?: string | null;
+    keyword_family?: string | null;
+    click_ids?: {
+      xclid?: string | null;
+      fbclid?: string | null;
+      gclid?: string | null;
+    };
+  };
+  company?: {
+    name?: string;
+    website?: string;
+    size?: string;
+    industry?: string;
+  };
+  contact?: {
+    name?: string;
+    email?: string;
+    phone?: string;
+    department?: string;
+    role?: string;
+  };
+  diagnosis?: {
+    target_function?: string;
+    ai_adoption_stage?: string;
+    pain?: string;
+    urgency?: string;
+    budget_signal?: string;
+    authority_signal?: string;
+    free_text?: string;
+  };
+  consent?: {
+    privacy_policy?: boolean;
+    marketing_contact?: boolean;
+  };
+};
+
+export type IntakeStableIds = {
+  brainbase_customer_id: string;
+  brainbase_contact_id: string;
+  brainbase_push_case_id: string;
+  diagnosis_id: string;
+};
+
+export type DedupePlan = {
+  customer: {
+    key: string;
+    id: string;
+    action: 'upsert';
+  };
+  contact: {
+    key: string;
+    id: string;
+    action: 'upsert';
+  };
+  push_case: {
+    key: string;
+    id: string;
+    action: 'upsert';
+  };
+  diagnosis: {
+    key: string;
+    id: string;
+    action: 'create';
+  };
+};
+
+export type GraphEntity = {
+  id: string;
+  entityType: 'customer' | 'contact' | 'push_case' | 'diagnosis';
+  projectCode: 'unson';
+  projectName: 'Unson';
+  roleMin: 'gm';
+  sensitivity: 'restricted';
+  payload: Record<string, unknown>;
+};
+
+export type GraphEdge = {
+  fromId: string;
+  toId: string;
+  relType:
+    | 'has_push_case'
+    | 'participates_in'
+    | 'primary_contact_for'
+    | 'has_diagnosis'
+    | 'belongs_to_customer'
+    | 'governed_by';
+};
+
+export type PostHogCapturePlan = {
+  event: 'diagnosis_form_submit';
+  distinct_id: string;
+  timestamp: string;
+  properties: Record<string, unknown>;
+};
+
+export type NocoDbProjectionPlan = {
+  baseId: 'pipf5irgs2lzuon';
+  tableName: '推進案件';
+  fields: Record<string, unknown>;
+};
+
+export type IntakeDryRunResponse = {
+  ok: boolean;
+  dry_run: true;
+  validation: IntakeValidation;
+  ids?: IntakeStableIds;
+  dedupe?: DedupePlan;
+  write_plan: string[];
+  graph: {
+    entities: GraphEntity[];
+    edges: GraphEdge[];
+  };
+  posthog?: PostHogCapturePlan;
+  nocodb_projection?: NocoDbProjectionPlan;
+  next?: 'booking';
+};

--- a/apps/lp-suite/src/lib/ai-employee-intake/validate.ts
+++ b/apps/lp-suite/src/lib/ai-employee-intake/validate.ts
@@ -1,0 +1,71 @@
+import type { AiEmployeeIntakeRequest, IntakeValidation, ValidationIssue } from './types';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isBlank(value: unknown): boolean {
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
+function error(code: string, message: string, path: string): ValidationIssue {
+  return { code, message, severity: 'error', path };
+}
+
+function warning(code: string, message: string, path: string): ValidationIssue {
+  return { code, message, severity: 'warning', path };
+}
+
+export function validateIntake(input: AiEmployeeIntakeRequest): IntakeValidation {
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+  const email = input.contact?.email?.trim();
+
+  if (isBlank(input.company?.name)) {
+    errors.push(error('missing_company_name', 'company.name is required.', 'company.name'));
+  }
+
+  if (isBlank(input.contact?.name)) {
+    errors.push(error('missing_contact_name', 'contact.name is required.', 'contact.name'));
+  }
+
+  if (isBlank(email)) {
+    errors.push(error('missing_contact_email', 'contact.email is required.', 'contact.email'));
+  } else if (!EMAIL_PATTERN.test(email || '')) {
+    errors.push(error('invalid_contact_email', 'contact.email must be a valid email address.', 'contact.email'));
+  }
+
+  if (input.consent?.privacy_policy !== true) {
+    errors.push(error('missing_privacy_consent', 'consent.privacy_policy must be true.', 'consent.privacy_policy'));
+  }
+
+  if (isBlank(input.diagnosis?.target_function)) {
+    errors.push(error('missing_target_function', 'diagnosis.target_function is required.', 'diagnosis.target_function'));
+  }
+
+  if (isBlank(input.diagnosis?.pain)) {
+    errors.push(error('missing_pain', 'diagnosis.pain is required.', 'diagnosis.pain'));
+  }
+
+  if (isBlank(input.diagnosis?.urgency)) {
+    errors.push(error('missing_urgency', 'diagnosis.urgency is required.', 'diagnosis.urgency'));
+  }
+
+  if (isBlank(input.submitted_at)) {
+    errors.push(error('missing_submitted_at', 'submitted_at is required.', 'submitted_at'));
+  } else if (Number.isNaN(Date.parse(input.submitted_at || ''))) {
+    errors.push(error('invalid_submitted_at', 'submitted_at must be an ISO datetime.', 'submitted_at'));
+  }
+
+  if (isBlank(input.diagnosis?.budget_signal) || input.diagnosis?.budget_signal === 'unknown') {
+    warnings.push(warning('budget_unknown', 'budget_signal is unknown.', 'diagnosis.budget_signal'));
+  }
+
+  if (isBlank(input.diagnosis?.authority_signal) || input.diagnosis?.authority_signal === 'unknown') {
+    warnings.push(warning('authority_unknown', 'authority_signal is unknown.', 'diagnosis.authority_signal'));
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}

--- a/apps/lp-suite/src/lib/env-auto-configurator.ts
+++ b/apps/lp-suite/src/lib/env-auto-configurator.ts
@@ -51,7 +51,7 @@ export class LPEnvironmentConfigurator {
       NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABEL: conversionLabel
     } as GoogleAdsEnvConfig;
 
-    await this.writeEnvFile(envPath, updatedConfig as Record<string, string>);
+    await this.writeEnvFile(envPath, updatedConfig as unknown as Record<string, string>);
     console.log(`✅ Updated conversion settings: ${envPath}`);
   }
 

--- a/apps/lp-suite/src/lib/utils.ts
+++ b/apps/lp-suite/src/lib/utils.ts
@@ -4,3 +4,70 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getApiBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_API_URL) return process.env.NEXT_PUBLIC_API_URL
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
+  return process.env.NODE_ENV === 'production' ? 'https://unsonos-api.vercel.app' : 'http://localhost:3000'
+}
+
+export function isMobileDevice(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.innerWidth < 768
+}
+
+export function getTrendArrow(trend: string): string {
+  if (trend === 'up') return '↗'
+  if (trend === 'down') return '↘'
+  return '→'
+}
+
+export function getTrendColor(trend: string): string {
+  if (trend === 'up') return 'text-green-600'
+  if (trend === 'down') return 'text-red-600'
+  return 'text-gray-600'
+}
+
+export function getTrendIconClass(trend: string): string {
+  const base = 'w-4 h-4'
+  if (trend === 'up') return `${base} text-green-500`
+  if (trend === 'down') return `${base} text-red-500`
+  return `${base} text-gray-500`
+}
+
+export function getStatusIcon(status: string): string {
+  if (status === 'RUNNING' || status === 'active') return '🟢'
+  if (status === 'OPTIMIZING' || status === 'pending') return '🟡'
+  if (status === 'CLOSED' || status === 'failed') return '🔴'
+  return '⚪'
+}
+
+export function getGradeColor(grade: string): string {
+  if (grade === 'A+' || grade === 'A') return 'text-green-700 bg-green-50'
+  if (grade === 'B') return 'text-blue-700 bg-blue-50'
+  if (grade === 'C') return 'text-yellow-700 bg-yellow-50'
+  return 'text-red-700 bg-red-50'
+}
+
+export function getActionColor(action: string): string {
+  if (action.includes('停止') || action.includes('終了')) return 'text-red-700 bg-red-50'
+  if (action.includes('改善') || action.includes('最適化')) return 'text-yellow-700 bg-yellow-50'
+  return 'text-blue-700 bg-blue-50'
+}
+
+export function formatDateSeparator(date: Date): string {
+  return date.toLocaleDateString('ja-JP', {
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  })
+}
+
+export function shouldShowDateSeparator(current: Date, previous: Date | null): boolean {
+  if (!previous) return true
+  return current.toDateString() !== previous.toDateString()
+}
+
+export function isNearBottom(element: HTMLElement, threshold = 100): boolean {
+  return element.scrollTop + element.clientHeight >= element.scrollHeight - threshold
+}

--- a/convex/discordApplications.ts
+++ b/convex/discordApplications.ts
@@ -15,7 +15,7 @@ export const create = mutation({
     // 既存の申請があるかチェック
     const existing = await ctx.db
       .query("discordApplications")
-      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .filter((q) => q.eq(q.field("email"), args.email))
       .first();
 
     if (existing && existing.status === "approved") {
@@ -79,7 +79,7 @@ export const getByEmail = query({
   handler: async (ctx, args) => {
     return await ctx.db
       .query("discordApplications")
-      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .filter((q) => q.eq(q.field("email"), args.email))
       .first();
   },
 });
@@ -91,7 +91,6 @@ export const getRecent = query({
     const limit = args.limit || 50;
     return await ctx.db
       .query("discordApplications")
-      .withIndex("by_creation_time")
       .order("desc")
       .take(limit);
   },

--- a/convex/playbooks.ts
+++ b/convex/playbooks.ts
@@ -53,7 +53,7 @@ export const startPlaybookRun = mutation({
     
     return await ctx.db.insert("playbookRuns", {
       workspace_id: args.workspace_id,
-      productId: args.productId,
+      product_id: args.productId,
       productName: args.productName,
       playbookId: args.playbookId,
       phase: args.phase,
@@ -101,7 +101,7 @@ export const getProductPlaybookRuns = query({
     return await ctx.db
       .query("playbookRuns")
       .withIndex("by_workspace_product", (q) => 
-        q.eq("workspace_id", args.workspace_id).eq("productId", args.productId))
+        q.eq("workspace_id", args.workspace_id).eq("product_id", args.productId))
       .order("desc")
       .collect();
   },
@@ -129,7 +129,7 @@ export const createPhaseReview = mutation({
     
     return await ctx.db.insert("phaseReviews", {
       workspace_id: args.workspace_id,
-      productId: args.productId,
+      product_id: args.productId,
       productName: args.productName,
       phase: args.phase,
       status: "in_progress",
@@ -179,7 +179,7 @@ export const getProductPhaseReviews = query({
     return await ctx.db
       .query("phaseReviews")
       .withIndex("by_workspace_product", (q) => 
-        q.eq("workspace_id", args.workspace_id).eq("productId", args.productId))
+        q.eq("workspace_id", args.workspace_id).eq("product_id", args.productId))
       .order("desc")
       .collect();
   },

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -144,6 +144,8 @@ export const search = query({
 // プロダクト作成
 export const create = mutation({
   args: {
+    workspace_id: v.optional(v.string()),
+    product_id: v.optional(v.string()),
     name: v.string(),
     category: v.string(),
     description: v.string(),
@@ -171,9 +173,16 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
+    const fallbackProductId = args.name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || `product-${now}`;
     
     const productId = await ctx.db.insert("products", {
       ...args,
+      workspace_id: args.workspace_id || "unson-os-workspace",
+      product_id: args.product_id || fallbackProductId,
       createdAt: now,
       updatedAt: now,
     });

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -15,7 +15,7 @@ export const add = mutation({
     // 重複チェック
     const existing = await ctx.db
       .query("waitlist")
-      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .filter((q) => q.eq(q.field("email"), args.email))
       .first();
     
     if (existing) {
@@ -96,7 +96,7 @@ export const checkEmail = query({
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query("waitlist")
-      .withIndex("by_email", (q) => q.eq("email", args.email))
+      .filter((q) => q.eq(q.field("email"), args.email))
       .first();
     
     return { exists: !!existing };


### PR DESCRIPTION
## Summary\n- Add dry-run intake endpoint for AI employee diagnosis submissions\n- Generate planned Graph entities/edges, PostHog event payload, and NocoDB 推進案件 projection without side effects\n- Add targeted Vitest coverage for validation, push_case-centered CRM shape, route behavior, and projection IDs\n\n## Verification\n- npm test -- src/lib/ai-employee-intake/__tests__/transform.test.ts src/app/api/ai-employee-diagnosis/intake/__tests__/route.test.ts --run\n- npx tsc --noEmit --skipLibCheck --module esnext --moduleResolution bundler --target esnext --lib dom,dom.iterable,esnext --esModuleInterop --resolveJsonModule --isolatedModules src/lib/ai-employee-intake/*.ts\n\n## Notes\n- Full npm run type-check currently fails on existing unrelated lp-suite/convex errors outside this change.\n