### PR TITLE
feat(lp-suite): add AI employee simple diagnosis API

### DIFF
--- a/apps/lp-suite/src/app/api/ai-employee-diagnosis/simple/__tests__/route.test.ts
+++ b/apps/lp-suite/src/app/api/ai-employee-diagnosis/simple/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { POST } from '../route';
+
+const payload = {
+  submitted_at: '2026-04-26T00:00:00.000Z',
+  form_variant: 'simple_diagnosis_v1',
+  landing_page: '/ai-employee-diagnosis',
+  company: {
+    website: 'https://example.com',
+  },
+  diagnosis_seed: {
+    pain_category: 'sales_ops',
+    pain_text: '商談後の議事録整理とCRM更新が遅い',
+    urgency: 'this_quarter',
+  },
+  attribution: {
+    utm_source: 'x',
+    utm_medium: 'paid_social',
+    utm_campaign: 'ai_driven_management_202604',
+    keyword_family: 'ai_employee',
+  },
+};
+
+describe('POST /api/ai-employee-diagnosis/simple', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('会社URLと課題から簡易診断結果を返す', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          '<html><head><title>Example Inc.</title><meta name="description" content="B2B SaaS"></head><body><h1>営業支援SaaS</h1><h2>CRM連携</h2></body></html>',
+          {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          },
+        ),
+      ),
+    );
+
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/simple', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.result.primary_candidate.use_case_id).toBe('sales_ai_employee');
+    expect(body.company_snapshot.homepage_title).toBe('Example Inc.');
+    expect(body.handoff.intake_prefill.company.website).toBe('https://example.com');
+  });
+
+  it('ホームページ取得に失敗してもwarning付きで結果を返す', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network failed');
+      }),
+    );
+
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/simple', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.validation.warnings[0].code).toBe('homepage_fetch_failed');
+  });
+
+  it('private URLはSSRF対策としてブロックする', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/simple', {
+        method: 'POST',
+        body: JSON.stringify({
+          ...payload,
+          company: {
+            website: 'http://169.254.169.254/latest/meta-data',
+          },
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.validation.errors.map((issue: { code: string }) => issue.code)).toContain('invalid_company_website');
+  });
+
+  it('不正なJSONならvalidation errorを返す', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/ai-employee-diagnosis/simple', {
+        method: 'POST',
+        body: '{',
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.validation.errors[0].code).toBe('invalid_json');
+  });
+});

--- a/apps/lp-suite/src/app/api/ai-employee-diagnosis/simple/route.ts
+++ b/apps/lp-suite/src/app/api/ai-employee-diagnosis/simple/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+import { readHomepageSnapshot } from '@/lib/ai-employee-simple-diagnosis/homepage';
+import { captureSimpleDiagnosisEvent } from '@/lib/ai-employee-simple-diagnosis/posthog';
+import { buildSimpleDiagnosis } from '@/lib/ai-employee-simple-diagnosis/transform';
+import type { SimpleDiagnosisRequest } from '@/lib/ai-employee-simple-diagnosis/types';
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as SimpleDiagnosisRequest;
+    const initialResponse = buildSimpleDiagnosis(body);
+
+    if (!initialResponse.ok) {
+      return NextResponse.json(initialResponse, { status: 400 });
+    }
+
+    const homepageRead = await readHomepageSnapshot(body.company?.website || '');
+    const response = buildSimpleDiagnosis(body, homepageRead);
+    await captureSimpleDiagnosisEvent(response.posthog);
+
+    return NextResponse.json(response, { status: response.ok ? 200 : 400 });
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        validation: {
+          valid: false,
+          errors: [
+            {
+              code: 'invalid_json',
+              message: 'Request body must be valid JSON.',
+              severity: 'error',
+            },
+          ],
+          warnings: [],
+        },
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/__tests__/transform.test.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/__tests__/transform.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSimpleDiagnosis } from '../transform';
+import type { SimpleDiagnosisRequest } from '../types';
+
+const validRequest: SimpleDiagnosisRequest = {
+  submitted_at: '2026-04-26T00:00:00.000Z',
+  form_variant: 'simple_diagnosis_v1',
+  landing_page: '/ai-employee-diagnosis',
+  referrer: 'https://x.com/',
+  company: {
+    website: 'https://example.com',
+  },
+  diagnosis_seed: {
+    pain_category: 'sales_ops',
+    pain_text: '商談後の議事録整理とCRM更新が遅い',
+    current_tools: ['notion', 'slack', 'claude'],
+    team_size: '11-50',
+    urgency: 'this_quarter',
+  },
+  attribution: {
+    utm_source: 'x',
+    utm_medium: 'paid_social',
+    utm_campaign: 'ai_driven_management_202604',
+    utm_content: 'simple_diagnosis_hero_a',
+    utm_term: 'ai_employee',
+    keyword_family: 'ai_employee',
+    click_ids: {
+      xclid: 'x_123',
+      fbclid: null,
+      gclid: null,
+    },
+  },
+};
+
+describe('buildSimpleDiagnosis', () => {
+  it('URLと課題カテゴリだけでAI社員化候補と詳細診断handoffを返す', () => {
+    const result = buildSimpleDiagnosis({
+      ...validRequest,
+      diagnosis_seed: {
+        pain_category: 'sales_ops',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.simple_diagnosis_id).toMatch(/^simp_ai_employee_[a-z0-9]{10}$/);
+    expect(result.validation.valid).toBe(true);
+    expect(result.result?.primary_candidate.use_case_id).toBe('sales_ai_employee');
+    expect(result.result?.primary_candidate.title).toBe('営業AI社員');
+    expect(result.result?.cta.next_step).toBe('detailed_diagnosis');
+    expect(result.handoff?.intake_prefill.company.website).toBe('https://example.com');
+    expect(result.handoff?.intake_prefill.diagnosis.free_text).toContain(result.simple_diagnosis_id);
+  });
+
+  it('ホームページ取得に失敗してもwarning付きで入力内容から結果を返す', () => {
+    const result = buildSimpleDiagnosis(validRequest, {
+      warnings: [
+        {
+          code: 'homepage_fetch_failed',
+          message: 'ホームページの読み取りはできませんでしたが、入力内容から診断できます',
+          severity: 'warning',
+          path: 'company.website',
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.validation.warnings.map((issue) => issue.code)).toContain('homepage_fetch_failed');
+    expect(result.company_snapshot.confidence).toBe('low');
+    expect(result.posthog?.properties.homepage_fetch_status).toBe('failed');
+  });
+
+  it('URLが空なら結果を返さない', () => {
+    const result = buildSimpleDiagnosis({
+      ...validRequest,
+      company: {
+        website: '',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.validation.errors.map((issue) => issue.code)).toContain('missing_company_website');
+    expect(result.result).toBeUndefined();
+  });
+
+  it('URL形式が不正なら結果を返さない', () => {
+    const result = buildSimpleDiagnosis({
+      ...validRequest,
+      company: {
+        website: 'not-a-url',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.validation.errors.map((issue) => issue.code)).toContain('invalid_company_website');
+    expect(result.posthog).toBeUndefined();
+  });
+
+  it('課題カテゴリと自由入力が両方空なら結果を返さない', () => {
+    const result = buildSimpleDiagnosis({
+      ...validRequest,
+      diagnosis_seed: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.validation.errors.map((issue) => issue.code)).toContain('missing_pain_signal');
+  });
+
+  it('個人情報入力要求やGraph/NocoDB write planを含めない', () => {
+    const result = buildSimpleDiagnosis(validRequest);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain('contact');
+    expect(serialized).not.toContain('email');
+    expect(serialized).not.toContain('write_plan');
+    expect(serialized).not.toContain('nocodb');
+    expect(serialized).not.toContain('graph');
+    expect(result.posthog?.event).toBe('simple_diagnosis_completed');
+    expect(result.posthog?.properties.simple_diagnosis_id).toBe(result.simple_diagnosis_id);
+  });
+});

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/homepage.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/homepage.ts
@@ -1,0 +1,158 @@
+import type { HomepageReadResult, HomepageSnapshot } from './types';
+import { normalizeWebsite, validateCompanyWebsite, warning } from './validate';
+
+const MAX_BODY_BYTES = 300 * 1024;
+const MAX_EXTRACTED_TEXT = 4000;
+const MAX_REDIRECTS = 3;
+const TIMEOUT_MS = 5000;
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractFirstMatch(html: string, pattern: RegExp): string {
+  const match = html.match(pattern);
+  return (match?.[1] || '').replace(/\s+/g, ' ').trim();
+}
+
+function extractHeadings(html: string): string[] {
+  const headings = Array.from(html.matchAll(/<h[12][^>]*>([\s\S]*?)<\/h[12]>/gi))
+    .map((match) => stripTags(match[1]))
+    .filter(Boolean);
+
+  return headings.slice(0, 6);
+}
+
+function summarizeHomepage(text: string, hostname: string): string {
+  const trimmed = text.slice(0, 180).trim();
+  if (!trimmed) {
+    return `${hostname} の公開情報を確認しました。詳細診断では実際の業務フローを確認します。`;
+  }
+
+  return `${trimmed}... 公開情報と課題入力からAI社員化候補を出しています。`;
+}
+
+async function fetchTextWithLimit(url: string): Promise<{ text: string; finalUrl: string }> {
+  let currentUrl = url;
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      const response = await fetch(currentUrl, {
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+
+      if ([301, 302, 303, 307, 308].includes(response.status)) {
+        const location = response.headers.get('location');
+        if (!location) throw new Error('Redirect location is missing.');
+
+        const nextUrl = new URL(location, currentUrl).toString();
+        const validation = validateCompanyWebsite(nextUrl);
+        if (validation) throw new Error('Blocked redirect URL.');
+
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      if (!response.ok) throw new Error(`Homepage responded with ${response.status}.`);
+
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.includes('text/html') && !contentType.includes('text/plain')) {
+        throw new Error('Homepage response is not HTML.');
+      }
+
+      const contentLength = Number(response.headers.get('content-length') || '0');
+      if (contentLength > MAX_BODY_BYTES) throw new Error('Homepage response is too large.');
+
+      const text = (await response.text()).slice(0, MAX_BODY_BYTES);
+      return { text, finalUrl: currentUrl };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw new Error('Too many redirects.');
+}
+
+export function buildInputOnlySnapshot(website: string): HomepageSnapshot {
+  const normalizedWebsite = normalizeWebsite(website);
+  const parsed = new URL(normalizedWebsite);
+
+  return {
+    website: normalizedWebsite,
+    hostname: parsed.hostname,
+    inferred_company_name: parsed.hostname,
+    homepage_title: '',
+    homepage_summary: 'ホームページの読み取りはできませんでしたが、入力内容から診断しています。',
+    confidence: 'low',
+    source: 'input_only',
+  };
+}
+
+export function parseHomepageSnapshot(website: string, html: string, finalUrl?: string): HomepageSnapshot {
+  const normalizedWebsite = normalizeWebsite(finalUrl || website);
+  const parsed = new URL(normalizedWebsite);
+  const title = extractFirstMatch(html, /<title[^>]*>([\s\S]*?)<\/title>/i);
+  const description = extractFirstMatch(
+    html,
+    /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["'][^>]*>/i,
+  );
+  const headings = extractHeadings(html);
+  const bodyText = stripTags(html).slice(0, MAX_EXTRACTED_TEXT);
+  const signalText = [description, ...headings, bodyText].filter(Boolean).join(' ').slice(0, MAX_EXTRACTED_TEXT);
+
+  return {
+    website: normalizedWebsite,
+    hostname: parsed.hostname,
+    inferred_company_name: title || parsed.hostname,
+    homepage_title: title,
+    homepage_summary: summarizeHomepage(signalText, parsed.hostname),
+    confidence: signalText.length > 120 ? 'medium' : 'low',
+    source: 'homepage',
+  };
+}
+
+export async function readHomepageSnapshot(website: string): Promise<HomepageReadResult> {
+  const normalizedWebsite = normalizeWebsite(website);
+  const validation = validateCompanyWebsite(normalizedWebsite);
+
+  if (validation) {
+    return { warnings: [validation] };
+  }
+
+  try {
+    const { text, finalUrl } = await fetchTextWithLimit(normalizedWebsite);
+    const snapshot = parseHomepageSnapshot(normalizedWebsite, text, finalUrl);
+    const warnings =
+      snapshot.confidence === 'low'
+        ? [
+            warning(
+              'homepage_low_signal',
+              '公開情報が少ないため、課題入力を中心に診断しています',
+              'company.website',
+            ),
+          ]
+        : [];
+
+    return { snapshot, warnings };
+  } catch {
+    return {
+      snapshot: buildInputOnlySnapshot(normalizedWebsite),
+      warnings: [
+        warning(
+          'homepage_fetch_failed',
+          'ホームページの読み取りはできませんでしたが、入力内容から診断できます',
+          'company.website',
+        ),
+      ],
+    };
+  }
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/ids.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/ids.ts
@@ -1,0 +1,24 @@
+import type { SimpleDiagnosisRequest } from './types';
+import { normalizeWebsite } from './validate';
+
+function hash10(input: string): string {
+  let hash = 5381;
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(index);
+  }
+
+  const unsigned = hash >>> 0;
+  return unsigned.toString(36).padStart(10, '0').slice(0, 10);
+}
+
+export function buildSimpleDiagnosisId(input: SimpleDiagnosisRequest): string {
+  const submittedDate = (input.submitted_at || new Date().toISOString()).slice(0, 10);
+  const key = [
+    normalizeWebsite(input.company?.website).toLowerCase(),
+    input.diagnosis_seed?.pain_category || 'unknown',
+    input.diagnosis_seed?.pain_text || '',
+    submittedDate,
+  ].join('|');
+
+  return `simp_ai_employee_${hash10(key)}`;
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/posthog.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/posthog.ts
@@ -1,0 +1,28 @@
+import type { SimpleDiagnosisPostHogPlan } from './types';
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+export async function captureSimpleDiagnosisEvent(plan?: SimpleDiagnosisPostHogPlan): Promise<void> {
+  const apiKey = process.env.POSTHOG_API_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!apiKey || !plan) return;
+
+  const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || DEFAULT_POSTHOG_HOST;
+  const distinctId = String(plan.properties.simple_diagnosis_id || 'anonymous');
+
+  try {
+    await fetch(`${host.replace(/\/$/, '')}/capture/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_key: apiKey,
+        event: plan.event,
+        distinct_id: distinctId,
+        properties: plan.properties,
+      }),
+    });
+  } catch {
+    // 診断結果を先に返す。計測失敗でユーザー体験を止めない。
+  }
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/transform.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/transform.ts
@@ -1,0 +1,130 @@
+import { buildSimpleDiagnosisId } from './ids';
+import type {
+  HomepageReadResult,
+  HomepageSnapshot,
+  IntakePrefill,
+  SimpleDiagnosisRequest,
+  SimpleDiagnosisResponse,
+  SimpleDiagnosisResult,
+  UseCaseDefinition,
+  ValidationIssue,
+} from './types';
+import { getUseCaseDefinition } from './use-case-map';
+import { normalizeWebsite, validateSimpleDiagnosis } from './validate';
+import { buildInputOnlySnapshot } from './homepage';
+
+function mergeWarnings(...warningGroups: Array<ValidationIssue[] | undefined>): ValidationIssue[] {
+  return warningGroups.flatMap((warnings) => warnings || []);
+}
+
+function buildResult(definition: UseCaseDefinition): SimpleDiagnosisResult {
+  return {
+    headline: '貴社で最初にAI社員化しやすい業務候補',
+    primary_candidate: {
+      use_case_id: definition.primary_use_case,
+      title: definition.title,
+      target_workflow: definition.target_workflow,
+      reason: definition.reason,
+      first_poc_scope: definition.first_poc_scope,
+    },
+    claude_code_use_cases: definition.claude_code_use_cases,
+    expected_change:
+      '人間が毎回AIに指示する状態から、AI社員が業務フロー内で下書き/整理/記録まで進める状態へ。',
+    likely_bottlenecks: definition.likely_bottlenecks,
+    detail_diagnosis_agenda: [
+      '実際の業務フローを確認する',
+      '利用ツールとデータの場所を確認する',
+      'PoC候補を1つに絞る',
+    ],
+    cta: {
+      label: 'この結果をもとに30分でPoC候補を1つに絞る',
+      next_step: 'detailed_diagnosis',
+    },
+  };
+}
+
+function buildHandoff(
+  input: SimpleDiagnosisRequest,
+  snapshot: HomepageSnapshot,
+  definition: UseCaseDefinition,
+  simpleDiagnosisId: string,
+): { intake_prefill: IntakePrefill } {
+  const painText = input.diagnosis_seed?.pain_text || definition.target_workflow;
+
+  return {
+    intake_prefill: {
+      company: {
+        website: normalizeWebsite(input.company?.website),
+        name: snapshot.inferred_company_name || snapshot.hostname,
+      },
+      diagnosis: {
+        target_function: definition.target_function,
+        pain: painText,
+        urgency: input.diagnosis_seed?.urgency || 'unknown',
+        free_text: `simple_diagnosis_id=${simpleDiagnosisId} / primary_use_case=${definition.primary_use_case}`,
+      },
+      attribution: {
+        utm_source: input.attribution?.utm_source || null,
+        utm_medium: input.attribution?.utm_medium || null,
+        utm_campaign: input.attribution?.utm_campaign || null,
+        utm_content: input.attribution?.utm_content || null,
+        keyword_family: input.attribution?.keyword_family || null,
+      },
+    },
+  };
+}
+
+function homepageFetchStatus(snapshot: HomepageSnapshot, warnings: ValidationIssue[]): string {
+  if (warnings.some((issue) => issue.code === 'homepage_fetch_failed')) return 'failed';
+  if (warnings.some((issue) => issue.code === 'homepage_low_signal')) return 'low_signal';
+  return snapshot.source === 'homepage' ? 'success' : 'input_only';
+}
+
+export function buildSimpleDiagnosis(
+  input: SimpleDiagnosisRequest,
+  homepageRead?: HomepageReadResult,
+): SimpleDiagnosisResponse {
+  const validation = validateSimpleDiagnosis(input);
+
+  if (!validation.valid) {
+    return {
+      ok: false,
+      validation,
+    };
+  }
+
+  const simpleDiagnosisId = buildSimpleDiagnosisId(input);
+  const definition = getUseCaseDefinition(input.diagnosis_seed?.pain_category);
+  const snapshot = homepageRead?.snapshot || buildInputOnlySnapshot(normalizeWebsite(input.company?.website));
+  const warnings = mergeWarnings(validation.warnings, homepageRead?.warnings);
+  const result = buildResult(definition);
+
+  return {
+    ok: true,
+    simple_diagnosis_id: simpleDiagnosisId,
+    validation: {
+      ...validation,
+      warnings,
+    },
+    company_snapshot: snapshot,
+    result,
+    handoff: buildHandoff(input, snapshot, definition, simpleDiagnosisId),
+    posthog: {
+      event: 'simple_diagnosis_completed',
+      properties: {
+        simple_diagnosis_id: simpleDiagnosisId,
+        company_website_domain: snapshot.hostname,
+        pain_category: definition.pain_category,
+        primary_use_case: definition.primary_use_case,
+        result_confidence: snapshot.confidence,
+        homepage_fetch_status: homepageFetchStatus(snapshot, warnings),
+        keyword_family: input.attribution?.keyword_family || null,
+        utm_source: input.attribution?.utm_source || null,
+        utm_medium: input.attribution?.utm_medium || null,
+        utm_campaign: input.attribution?.utm_campaign || null,
+        utm_content: input.attribution?.utm_content || null,
+        utm_term: input.attribution?.utm_term || null,
+      },
+    },
+  };
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/types.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/types.ts
@@ -1,0 +1,143 @@
+export type ValidationSeverity = 'error' | 'warning';
+
+export type ValidationIssue = {
+  code: string;
+  message: string;
+  severity: ValidationSeverity;
+  path?: string;
+};
+
+export type SimpleDiagnosisValidation = {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+};
+
+export type SimpleDiagnosisRequest = {
+  submitted_at?: string;
+  form_variant?: string;
+  landing_page?: string;
+  referrer?: string;
+  company?: {
+    website?: string;
+  };
+  diagnosis_seed?: {
+    pain_category?: PainCategory | string;
+    pain_text?: string;
+    current_tools?: string[];
+    team_size?: string;
+    urgency?: string;
+  };
+  attribution?: {
+    utm_source?: string | null;
+    utm_medium?: string | null;
+    utm_campaign?: string | null;
+    utm_content?: string | null;
+    utm_term?: string | null;
+    keyword_family?: string | null;
+    click_ids?: {
+      xclid?: string | null;
+      fbclid?: string | null;
+      gclid?: string | null;
+    };
+  };
+};
+
+export type PainCategory =
+  | 'sales_ops'
+  | 'pm_dev'
+  | 'research_docs'
+  | 'management_ops'
+  | 'support_backoffice'
+  | 'unknown';
+
+export type PrimaryUseCase =
+  | 'sales_ai_employee'
+  | 'pm_dev_ai_employee'
+  | 'research_ai_employee'
+  | 'management_ai_employee'
+  | 'ops_ai_employee'
+  | 'workflow_discovery';
+
+export type HomepageSnapshot = {
+  website: string;
+  hostname: string;
+  inferred_company_name: string;
+  homepage_title: string;
+  homepage_summary: string;
+  confidence: 'low' | 'medium' | 'high';
+  source: 'homepage' | 'input_only';
+};
+
+export type HomepageReadResult = {
+  snapshot?: HomepageSnapshot;
+  warnings?: ValidationIssue[];
+};
+
+export type UseCaseDefinition = {
+  pain_category: PainCategory;
+  primary_use_case: PrimaryUseCase;
+  target_function: string;
+  title: string;
+  target_workflow: string;
+  reason: string;
+  first_poc_scope: string;
+  claude_code_use_cases: string[];
+  likely_bottlenecks: string[];
+};
+
+export type SimpleDiagnosisResult = {
+  headline: string;
+  primary_candidate: {
+    use_case_id: PrimaryUseCase;
+    title: string;
+    target_workflow: string;
+    reason: string;
+    first_poc_scope: string;
+  };
+  claude_code_use_cases: string[];
+  expected_change: string;
+  likely_bottlenecks: string[];
+  detail_diagnosis_agenda: string[];
+  cta: {
+    label: string;
+    next_step: 'detailed_diagnosis';
+  };
+};
+
+export type SimpleDiagnosisPostHogPlan = {
+  event: 'simple_diagnosis_completed';
+  properties: Record<string, unknown>;
+};
+
+export type IntakePrefill = {
+  company: {
+    website: string;
+    name: string;
+  };
+  diagnosis: {
+    target_function: string;
+    pain: string;
+    urgency: string;
+    free_text: string;
+  };
+  attribution: {
+    utm_source?: string | null;
+    utm_medium?: string | null;
+    utm_campaign?: string | null;
+    utm_content?: string | null;
+    keyword_family?: string | null;
+  };
+};
+
+export type SimpleDiagnosisResponse = {
+  ok: boolean;
+  simple_diagnosis_id?: string;
+  validation: SimpleDiagnosisValidation;
+  company_snapshot?: HomepageSnapshot;
+  result?: SimpleDiagnosisResult;
+  handoff?: {
+    intake_prefill: IntakePrefill;
+  };
+  posthog?: SimpleDiagnosisPostHogPlan;
+};

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/use-case-map.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/use-case-map.ts
@@ -1,0 +1,130 @@
+import type { PainCategory, UseCaseDefinition } from './types';
+
+const DEFINITIONS: Record<PainCategory, UseCaseDefinition> = {
+  sales_ops: {
+    pain_category: 'sales_ops',
+    primary_use_case: 'sales_ai_employee',
+    target_function: 'sales',
+    title: '営業AI社員',
+    target_workflow: '商談後の議事録整理、CRM更新、次アクション作成',
+    reason: '入力、判断、出力が定型化しやすく、毎週発生する業務だから',
+    first_poc_scope: '商談メモからCRM更新案と次アクションを生成する',
+    claude_code_use_cases: [
+      '商談メモからCRM更新案を生成する',
+      '提案書のたたき台を作る',
+      '次アクションと担当者を抽出する',
+    ],
+    likely_bottlenecks: [
+      'どこまでAIに任せるかが曖昧',
+      '人間が確認すべき判断境界が未定',
+      'CRMや議事録の正本が分かれている',
+    ],
+  },
+  pm_dev: {
+    pain_category: 'pm_dev',
+    primary_use_case: 'pm_dev_ai_employee',
+    target_function: 'product_development',
+    title: 'PM/開発AI社員',
+    target_workflow: '要件定義、仕様化、Issue分解、レビュー観点生成',
+    reason: '曖昧な依頼を開発可能な単位へ落とす反復作業が多いから',
+    first_poc_scope: '議事録や要望からIssue分解と受け入れ条件を作る',
+    claude_code_use_cases: [
+      '要望から仕様ドラフトを作る',
+      'Issueを実装可能な粒度へ分解する',
+      'レビュー観点とテスト観点を生成する',
+    ],
+    likely_bottlenecks: [
+      '要求の正本が会話とドキュメントに分散している',
+      '完了条件が曖昧なまま実装に進む',
+      'AIが触ってよい範囲と人間承認の境界が未定',
+    ],
+  },
+  research_docs: {
+    pain_category: 'research_docs',
+    primary_use_case: 'research_ai_employee',
+    target_function: 'research',
+    title: '調査AI社員',
+    target_workflow: '市場/競合調査brief、資料下書き、示唆抽出',
+    reason: '情報収集、整理、仮説化を同じ型で繰り返しやすいから',
+    first_poc_scope: '競合調査briefと示唆メモを毎週作成する',
+    claude_code_use_cases: [
+      '調査観点を分解してbriefを作る',
+      '公開情報から比較表を作る',
+      '資料のたたき台と示唆を抽出する',
+    ],
+    likely_bottlenecks: [
+      '一次情報と推測が混ざりやすい',
+      '調査結果の活用先が不明確',
+      '更新頻度と鮮度管理が決まっていない',
+    ],
+  },
+  management_ops: {
+    pain_category: 'management_ops',
+    primary_use_case: 'management_ai_employee',
+    target_function: 'management',
+    title: '経営AI社員',
+    target_workflow: '会議ログから決定事項、タスク、Ship候補を抽出',
+    reason: '経営会議後の整理と実行接続がボトルネックになりやすいから',
+    first_poc_scope: '会議ログから決定記録、次アクション、推進案件候補を作る',
+    claude_code_use_cases: [
+      '会議ログから決定事項を抽出する',
+      'Ship候補とタスクを生成する',
+      '未決事項と論点を整理する',
+    ],
+    likely_bottlenecks: [
+      '決定事項と会話メモが分離していない',
+      '責任者と期限が曖昧',
+      'タスク化後の追跡場所が決まっていない',
+    ],
+  },
+  support_backoffice: {
+    pain_category: 'support_backoffice',
+    primary_use_case: 'ops_ai_employee',
+    target_function: 'operations',
+    title: '業務AI社員',
+    target_workflow: '問い合わせ、FAQ、請求/契約処理の下書き',
+    reason: '定型対応が多く、下書きと確認の分離で効果を出しやすいから',
+    first_poc_scope: '問い合わせ文面から回答案と社内確認事項を生成する',
+    claude_code_use_cases: [
+      '問い合わせから回答案を作る',
+      'FAQ候補を抽出する',
+      '請求/契約処理の確認リストを作る',
+    ],
+    likely_bottlenecks: [
+      '例外対応の判断基準が未整理',
+      '顧客情報の参照権限が曖昧',
+      '最終確認者が決まっていない',
+    ],
+  },
+  unknown: {
+    pain_category: 'unknown',
+    primary_use_case: 'workflow_discovery',
+    target_function: 'workflow_discovery',
+    title: '業務棚卸しAI社員',
+    target_workflow: '業務フロー棚卸し、AI社員化候補抽出',
+    reason: 'まず業務を見える化すると、AI社員化しやすい反復業務を特定できるから',
+    first_poc_scope: '主要業務を棚卸ししてAI社員化候補を3つに絞る',
+    claude_code_use_cases: [
+      '業務フローを分解する',
+      '反復業務と判断業務を分類する',
+      'PoC候補の優先順位を作る',
+    ],
+    likely_bottlenecks: [
+      'どの業務から始めるかが決まっていない',
+      '業務の正本が人に依存している',
+      '成果指標が曖昧',
+    ],
+  },
+};
+
+export function normalizePainCategory(category?: string): PainCategory {
+  if (category && category in DEFINITIONS) {
+    return category as PainCategory;
+  }
+
+  return 'unknown';
+}
+
+export function getUseCaseDefinition(category?: string): UseCaseDefinition {
+  return DEFINITIONS[normalizePainCategory(category)];
+}

--- a/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/validate.ts
+++ b/apps/lp-suite/src/lib/ai-employee-simple-diagnosis/validate.ts
@@ -1,0 +1,83 @@
+import type { SimpleDiagnosisRequest, SimpleDiagnosisValidation, ValidationIssue } from './types';
+
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^0\./,
+  /^169\.254\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^\[?::1\]?$/i,
+];
+
+function isBlank(value: unknown): boolean {
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
+export function error(code: string, message: string, path: string): ValidationIssue {
+  return { code, message, severity: 'error', path };
+}
+
+export function warning(code: string, message: string, path: string): ValidationIssue {
+  return { code, message, severity: 'warning', path };
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function normalizeWebsite(rawWebsite?: string): string {
+  const trimmed = rawWebsite?.trim() || '';
+  if (!trimmed) return '';
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+export function validateCompanyWebsite(rawWebsite?: string): ValidationIssue | null {
+  const website = normalizeWebsite(rawWebsite);
+
+  if (!website) {
+    return error('missing_company_website', '会社ホームページURLを入力してください', 'company.website');
+  }
+
+  try {
+    const parsed = new URL(website);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return error('invalid_company_website', 'URLの形式を確認してください', 'company.website');
+    }
+    if (!parsed.hostname.includes('.')) {
+      return error('invalid_company_website', 'URLの形式を確認してください', 'company.website');
+    }
+    if (isBlockedHostname(parsed.hostname)) {
+      return error('invalid_company_website', 'URLの形式を確認してください', 'company.website');
+    }
+  } catch {
+    return error('invalid_company_website', 'URLの形式を確認してください', 'company.website');
+  }
+
+  return null;
+}
+
+export function validateSimpleDiagnosis(input: SimpleDiagnosisRequest): SimpleDiagnosisValidation {
+  const errors: ValidationIssue[] = [];
+  const websiteError = validateCompanyWebsite(input.company?.website);
+
+  if (websiteError) {
+    errors.push(websiteError);
+  }
+
+  if (isBlank(input.diagnosis_seed?.pain_category) && isBlank(input.diagnosis_seed?.pain_text)) {
+    errors.push(error('missing_pain_signal', '近い課題を1つ選んでください', 'diagnosis_seed.pain_category'));
+  }
+
+  if (!isBlank(input.submitted_at) && Number.isNaN(Date.parse(input.submitted_at || ''))) {
+    errors.push(error('invalid_submitted_at', 'submitted_at must be an ISO datetime.', 'submitted_at'));
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings: [],
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23073,6 +23073,420 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",


### PR DESCRIPTION
## Summary
- Add POST /api/ai-employee-diagnosis/simple for the no-PII diagnosis preview flow
- Add deterministic use-case mapping, SSRF-safe homepage read, optional server-side PostHog capture, and detailed diagnosis handoff prefill
- Cover validation, homepage fetch fallback, SSRF blocking, and no Graph/NocoDB writes with Vitest
- Sync root package-lock esbuild optional dependencies so GitHub Actions npm ci can run

## Verification
- npx npm@10.8.2 ci --ignore-scripts
- npm run lint (passes with existing <img> warnings in src/components/sections/SimpleGitHubContributors.tsx)
- npm run test -- --run src/lib/ai-employee-simple-diagnosis/__tests__/transform.test.ts src/app/api/ai-employee-diagnosis/simple/__tests__/route.test.ts
- npm run type-check fails on existing ../../services/domain-automation/src/lib/route53-client.ts missing @aws-sdk/client-route-53

## CI note
- GitHub Actions Test passes after lockfile sync
- Deploy Preview still fails during Next build trace collection with micromatch Maximum call stack size exceeded; this appears in root Next build tracing after compilation, not in the simple diagnosis API tests